### PR TITLE
Update sdk according to the Open API  20230104's version

### DIFF
--- a/client/backup/backup_client.go
+++ b/client/backup/backup_client.go
@@ -44,7 +44,7 @@ type ClientService interface {
 
 	- For Dedicated Tier clusters, you can create as many manual backups as you need.
 
-- For Developer Tier clusters, you cannot create backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
+- For Serverless Tier clusters, you cannot create backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
 */
 func (a *Client) CreateBackup(params *CreateBackupParams, opts ...ClientOption) (*CreateBackupOK, error) {
 	// TODO: Validate the params before sending
@@ -83,7 +83,7 @@ func (a *Client) CreateBackup(params *CreateBackupParams, opts ...ClientOption) 
 /*
 DeleteBackup deletes a backup for a cluster
 
-For Developer Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
+For Serverless Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
 */
 func (a *Client) DeleteBackup(params *DeleteBackupParams, opts ...ClientOption) (*DeleteBackupOK, error) {
 	// TODO: Validate the params before sending
@@ -122,7 +122,7 @@ func (a *Client) DeleteBackup(params *DeleteBackupParams, opts ...ClientOption) 
 /*
 GetBackupOfCluster gets a backup for a cluster
 
-For Developer Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
+For Serverless Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
 */
 func (a *Client) GetBackupOfCluster(params *GetBackupOfClusterParams, opts ...ClientOption) (*GetBackupOfClusterOK, error) {
 	// TODO: Validate the params before sending
@@ -161,7 +161,7 @@ func (a *Client) GetBackupOfCluster(params *GetBackupOfClusterParams, opts ...Cl
 /*
 ListBackUpOfCluster lists all backups for a cluster
 
-For Developer Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
+For Serverless Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.
 */
 func (a *Client) ListBackUpOfCluster(params *ListBackUpOfClusterParams, opts ...ClientOption) (*ListBackUpOfClusterOK, error) {
 	// TODO: Validate the params before sending

--- a/client/cluster/create_cluster_responses.go
+++ b/client/cluster/create_cluster_responses.go
@@ -659,7 +659,7 @@ type CreateClusterBody struct {
 	CloudProvider *string `json:"cloud_provider"`
 
 	// The cluster type.
-	// - `"DEVELOPER"`: create a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
+	// - `"DEVELOPER"`: create a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
 	// - `"DEDICATED"`: create a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster. Before creating a Dedicated Tier cluster, you must [set a Project CIDR](https://docs.pingcap.com/tidbcloud/set-up-vpc-peering-connections#prerequisite-set-a-project-cidr) on [TiDB Cloud console](https://tidbcloud.com/).
 	// Example: DEDICATED
 	// Required: true
@@ -1264,7 +1264,7 @@ type CreateClusterParamsBodyConfig struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -1459,8 +1459,8 @@ CreateClusterParamsBodyConfigComponents The components of the cluster.
 //
 // **Limitations**:
 // - For a Dedicated Tier cluster, the `components` parameter is **required**.
-// - For a Developer Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// - For a Serverless Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 swagger:model CreateClusterParamsBodyConfigComponents
 */
 type CreateClusterParamsBodyConfigComponents struct {
@@ -1665,7 +1665,7 @@ type CreateClusterParamsBodyConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1752,7 +1752,7 @@ type CreateClusterParamsBodyConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1858,7 +1858,7 @@ type CreateClusterParamsBodyConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/client/cluster/get_cluster_responses.go
+++ b/client/cluster/get_cluster_responses.go
@@ -954,8 +954,10 @@ type GetClusterOKBody struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 
 	// The cluster type:
-	// - `"DEVELOPER"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
-	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.
+	// - `"DEVELOPER"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
+	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster
+	//
+	// **Warning:** `"DEVELOPER"` will soon be changed to `"SERVERLESS"` to represent Serverless Tier clusters.
 	// Example: DEDICATED
 	// Enum: [DEDICATED DEVELOPER]
 	ClusterType string `json:"cluster_type,omitempty"`
@@ -1250,7 +1252,7 @@ func (o *GetClusterOKBody) UnmarshalBinary(b []byte) error {
 
 /*
 GetClusterOKBodyConfig The configuration of the cluster.
-// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}},"port":4000}
+// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}},"port":4000}
 swagger:model GetClusterOKBodyConfig
 */
 type GetClusterOKBodyConfig struct {
@@ -1368,7 +1370,7 @@ func (o *GetClusterOKBodyConfig) UnmarshalBinary(b []byte) error {
 
 /*
 GetClusterOKBodyConfigComponents The components of the cluster.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 swagger:model GetClusterOKBodyConfigComponents
 */
 type GetClusterOKBodyConfigComponents struct {
@@ -1573,7 +1575,7 @@ type GetClusterOKBodyConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1660,7 +1662,7 @@ type GetClusterOKBodyConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1766,7 +1768,7 @@ type GetClusterOKBodyConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -2214,7 +2216,7 @@ type GetClusterOKBodyStatusConnectionStringsStandard struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -2289,7 +2291,7 @@ type GetClusterOKBodyStatusConnectionStringsVpcPeering struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -2365,7 +2367,7 @@ type GetClusterOKBodyStatusNodeMap struct {
 	Tiflash []*GetClusterOKBodyStatusNodeMapTiflashItems0 `json:"tiflash"`
 
 	// TiKV node map.
-	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
+	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C32G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
 	// Required: true
 	Tikv []*GetClusterOKBodyStatusNodeMapTikvItems0 `json:"tikv"`
 }
@@ -2825,7 +2827,7 @@ type GetClusterOKBodyStatusNodeMapTikvItems0 struct {
 	NodeName string `json:"node_name,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The RAM size of a node in the cluster. If the `cluster_type` is `"DEVELOPER"`, `ram_bytes` is always 0.

--- a/client/cluster/list_clusters_of_project_responses.go
+++ b/client/cluster/list_clusters_of_project_responses.go
@@ -1078,8 +1078,10 @@ type ListClustersOfProjectOKBodyItemsItems0 struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 
 	// The cluster type:
-	// - `"DEVELOPER"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
-	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.
+	// - `"DEVELOPER"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
+	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster
+	//
+	// **Warning:** `"DEVELOPER"` will soon be changed to `"SERVERLESS"` to represent Serverless Tier clusters.
 	// Example: DEDICATED
 	// Enum: [DEDICATED DEVELOPER]
 	ClusterType string `json:"cluster_type,omitempty"`
@@ -1374,7 +1376,7 @@ func (o *ListClustersOfProjectOKBodyItemsItems0) UnmarshalBinary(b []byte) error
 
 /*
 ListClustersOfProjectOKBodyItemsItems0Config The configuration of the cluster.
-// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}},"port":4000}
+// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}},"port":4000}
 swagger:model ListClustersOfProjectOKBodyItemsItems0Config
 */
 type ListClustersOfProjectOKBodyItemsItems0Config struct {
@@ -1492,7 +1494,7 @@ func (o *ListClustersOfProjectOKBodyItemsItems0Config) UnmarshalBinary(b []byte)
 
 /*
 ListClustersOfProjectOKBodyItemsItems0ConfigComponents The components of the cluster.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 swagger:model ListClustersOfProjectOKBodyItemsItems0ConfigComponents
 */
 type ListClustersOfProjectOKBodyItemsItems0ConfigComponents struct {
@@ -1697,7 +1699,7 @@ type ListClustersOfProjectOKBodyItemsItems0ConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1784,7 +1786,7 @@ type ListClustersOfProjectOKBodyItemsItems0ConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1890,7 +1892,7 @@ type ListClustersOfProjectOKBodyItemsItems0ConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -2338,7 +2340,7 @@ type ListClustersOfProjectOKBodyItemsItems0StatusConnectionStringsStandard struc
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -2413,7 +2415,7 @@ type ListClustersOfProjectOKBodyItemsItems0StatusConnectionStringsVpcPeering str
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -2489,7 +2491,7 @@ type ListClustersOfProjectOKBodyItemsItems0StatusNodeMap struct {
 	Tiflash []*ListClustersOfProjectOKBodyItemsItems0StatusNodeMapTiflashItems0 `json:"tiflash"`
 
 	// TiKV node map.
-	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
+	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C32G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
 	// Required: true
 	Tikv []*ListClustersOfProjectOKBodyItemsItems0StatusNodeMapTikvItems0 `json:"tikv"`
 }
@@ -2949,7 +2951,7 @@ type ListClustersOfProjectOKBodyItemsItems0StatusNodeMapTikvItems0 struct {
 	NodeName string `json:"node_name,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The RAM size of a node in the cluster. If the `cluster_type` is `"DEVELOPER"`, `ram_bytes` is always 0.

--- a/client/cluster/list_provider_regions_responses.go
+++ b/client/cluster/list_provider_regions_responses.go
@@ -947,7 +947,7 @@ swagger:model ListProviderRegionsOKBody
 type ListProviderRegionsOKBody struct {
 
 	// Items of provider regions.
-	// Example: [{"cloud_provider":"AWS","cluster_type":"DEDICATED","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"8C16G"}],"tiflash":[{"node_quantity_range":{"min":0,"step":1},"node_size":"8C64G","storage_size_gib_range":{"max":2048,"min":500}}],"tikv":[{"node_quantity_range":{"min":3,"step":3},"node_size":"8C64G","storage_size_gib_range":{"max":4096,"min":500}}]},{"cloud_provider":"AWS","cluster_type":"DEVELOPER","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0"}],"tiflash":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}],"tikv":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}]}]
+	// Example: [{"cloud_provider":"AWS","cluster_type":"DEDICATED","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"8C16G"}],"tiflash":[{"node_quantity_range":{"min":0,"step":1},"node_size":"8C64G","storage_size_gib_range":{"max":2048,"min":500}}],"tikv":[{"node_quantity_range":{"min":3,"step":3},"node_size":"8C32G","storage_size_gib_range":{"max":4096,"min":500}}]},{"cloud_provider":"AWS","cluster_type":"DEVELOPER","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0"}],"tiflash":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}],"tikv":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}]}]
 	Items []*ListProviderRegionsOKBodyItemsItems0 `json:"items"`
 }
 
@@ -1059,8 +1059,10 @@ type ListProviderRegionsOKBodyItemsItems0 struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 
 	// The cluster type.
-	// - `"DEVELOPER"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
+	// - `"DEVELOPER"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
 	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster
+	//
+	// **Warning:** `"DEVELOPER"` will soon be changed to `"SERVERLESS"` to represent Serverless Tier clusters.
 	// Example: DEDICATED
 	// Enum: [DEDICATED DEVELOPER]
 	ClusterType string `json:"cluster_type,omitempty"`
@@ -1744,7 +1746,7 @@ type ListProviderRegionsOKBodyItemsItems0TikvItems0 struct {
 	NodeQuantityRange *ListProviderRegionsOKBodyItemsItems0TikvItems0NodeQuantityRange `json:"node_quantity_range,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// storage size gib range

--- a/client/cluster/update_cluster_responses.go
+++ b/client/cluster/update_cluster_responses.go
@@ -1036,7 +1036,7 @@ UpdateClusterParamsBodyConfig UpdateClusterComponents
 // The configuration of the cluster. You can modify the components of the cluster using `components`, or pause or resume the cluster using `paused`.
 //
 //  You cannot change the cluster components and cluster status at the same time. That is, `components` and `paused` cannot be set at the same time.
-// Example: {"components":{"tidb":{"node_quantity":3},"tiflash":{"node_quantity":2,"node_size":"8C64G","storage_size_gib":1024},"tikv":{"node_quantity":6,"storage_size_gib":1024}}}
+// Example: {"components":{"tidb":{"node_quantity":3,"node_size":"16C32G"},"tiflash":{"node_quantity":2,"node_size":"16C128G","storage_size_gib":2048},"tikv":{"node_quantity":6,"node_size":"16C64G","storage_size_gib":2048}}}
 swagger:model UpdateClusterParamsBodyConfig
 */
 type UpdateClusterParamsBodyConfig struct {
@@ -1324,30 +1324,23 @@ type UpdateClusterParamsBodyConfigComponentsTidb struct {
 
 	// The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	// Example: 3
-	// Required: true
-	NodeQuantity *int32 `json:"node_quantity"`
+	NodeQuantity int32 `json:"node_quantity,omitempty"`
+
+	// The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiDB.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C32G
+	NodeSize string `json:"node_size,omitempty"`
 }
 
 // Validate validates this update cluster params body config components tidb
 func (o *UpdateClusterParamsBodyConfigComponentsTidb) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := o.validateNodeQuantity(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (o *UpdateClusterParamsBodyConfigComponentsTidb) validateNodeQuantity(formats strfmt.Registry) error {
-
-	if err := validate.Required("body"+"."+"config"+"."+"components"+"."+"tidb"+"."+"node_quantity", "body", o.NodeQuantity); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -1396,8 +1389,9 @@ type UpdateClusterParamsBodyConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
-	// Example: 8C64G
+	// - You cannot decrease node size for TiFlash.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C128G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
@@ -1405,7 +1399,7 @@ type UpdateClusterParamsBodyConfigComponentsTiflash struct {
 	// **Limitations**:
 	// - You cannot decrease storage size for TiFlash.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 
@@ -1451,12 +1445,24 @@ type UpdateClusterParamsBodyConfigComponentsTikv struct {
 	// Example: 6
 	NodeQuantity int32 `json:"node_quantity,omitempty"`
 
+	// The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiKV.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C64G
+	NodeSize string `json:"node_size,omitempty"`
+
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	//
 	// **Limitations**:
 	// - You cannot decrease storage size for TiKV.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 

--- a/client/restore/create_restore_task_responses.go
+++ b/client/restore/create_restore_task_responses.go
@@ -1134,7 +1134,7 @@ type CreateRestoreTaskParamsBodyConfig struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -1329,8 +1329,8 @@ CreateRestoreTaskParamsBodyConfigComponents The components of the cluster.
 //
 // **Limitations**:
 // - For a Dedicated Tier cluster, the `components` parameter is **required**.
-// - For a Developer Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// - For a Serverless Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 swagger:model CreateRestoreTaskParamsBodyConfigComponents
 */
 type CreateRestoreTaskParamsBodyConfigComponents struct {
@@ -1535,7 +1535,7 @@ type CreateRestoreTaskParamsBodyConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1622,7 +1622,7 @@ type CreateRestoreTaskParamsBodyConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1728,7 +1728,7 @@ type CreateRestoreTaskParamsBodyConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/client/restore/restore_client.go
+++ b/client/restore/restore_client.go
@@ -46,9 +46,9 @@ type ClientService interface {
 
 - For Dedicated Tier, you can only restore data from a smaller node size to a larger node size.
 
-- You cannot restore data from a Dedicated Tier cluster to a Developer Tier cluster.
+- You cannot restore data from a Dedicated Tier cluster to a Serverless Tier cluster.
 
-For Developer Tier clusters, you cannot create restore tasks via API.
+For Serverless Tier clusters, you cannot create restore tasks via API.
 */
 func (a *Client) CreateRestoreTask(params *CreateRestoreTaskParams, opts ...ClientOption) (*CreateRestoreTaskOK, error) {
 	// TODO: Validate the params before sending
@@ -87,7 +87,7 @@ func (a *Client) CreateRestoreTask(params *CreateRestoreTaskParams, opts ...Clie
 /*
 	GetRestoreTask gets a restore task
 
-For Developer Tier clusters, you cannot manage restore tasks via API.
+For Serverless Tier clusters, you cannot manage restore tasks via API.
 */
 func (a *Client) GetRestoreTask(params *GetRestoreTaskParams, opts ...ClientOption) (*GetRestoreTaskOK, error) {
 	// TODO: Validate the params before sending
@@ -126,7 +126,7 @@ func (a *Client) GetRestoreTask(params *GetRestoreTaskParams, opts ...ClientOpti
 /*
 	ListRestoreTasks lists the restore tasks in a project
 
-For Developer Tier clusters, you cannot create or manage restore tasks via API.
+For Serverless Tier clusters, you cannot create or manage restore tasks via API.
 */
 func (a *Client) ListRestoreTasks(params *ListRestoreTasksParams, opts ...ClientOption) (*ListRestoreTasksOK, error) {
 	// TODO: Validate the params before sending

--- a/models/openapi_cluster_components.go
+++ b/models/openapi_cluster_components.go
@@ -218,7 +218,7 @@ type OpenapiClusterComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -304,7 +304,7 @@ type OpenapiClusterComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -409,7 +409,7 @@ type OpenapiClusterComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/models/openapi_cluster_config.go
+++ b/models/openapi_cluster_config.go
@@ -29,7 +29,7 @@ type OpenapiClusterConfig struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -223,8 +223,8 @@ func (m *OpenapiClusterConfig) UnmarshalBinary(b []byte) error {
 //
 // **Limitations**:
 // - For a Dedicated Tier cluster, the `components` parameter is **required**.
-// - For a Developer Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// - For a Serverless Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 //
 // swagger:model OpenapiClusterConfigComponents
 type OpenapiClusterConfigComponents struct {
@@ -428,7 +428,7 @@ type OpenapiClusterConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -514,7 +514,7 @@ type OpenapiClusterConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -619,7 +619,7 @@ type OpenapiClusterConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/models/openapi_cluster_connection_strings.go
+++ b/models/openapi_cluster_connection_strings.go
@@ -168,7 +168,7 @@ type OpenapiClusterConnectionStringsStandard struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -242,7 +242,7 @@ type OpenapiClusterConnectionStringsVpcPeering struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024

--- a/models/openapi_cluster_item.go
+++ b/models/openapi_cluster_item.go
@@ -31,8 +31,10 @@ type OpenapiClusterItem struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 
 	// The cluster type:
-	// - `"DEVELOPER"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
-	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.
+	// - `"DEVELOPER"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
+	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster
+	//
+	// **Warning:** `"DEVELOPER"` will soon be changed to `"SERVERLESS"` to represent Serverless Tier clusters.
 	// Example: DEDICATED
 	// Enum: [DEDICATED DEVELOPER]
 	ClusterType string `json:"cluster_type,omitempty"`
@@ -326,7 +328,7 @@ func (m *OpenapiClusterItem) UnmarshalBinary(b []byte) error {
 }
 
 // OpenapiClusterItemConfig The configuration of the cluster.
-// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}},"port":4000}
+// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}},"port":4000}
 //
 // swagger:model OpenapiClusterItemConfig
 type OpenapiClusterItemConfig struct {
@@ -443,7 +445,7 @@ func (m *OpenapiClusterItemConfig) UnmarshalBinary(b []byte) error {
 }
 
 // OpenapiClusterItemConfigComponents The components of the cluster.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 //
 // swagger:model OpenapiClusterItemConfigComponents
 type OpenapiClusterItemConfigComponents struct {
@@ -647,7 +649,7 @@ type OpenapiClusterItemConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -733,7 +735,7 @@ type OpenapiClusterItemConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -838,7 +840,7 @@ type OpenapiClusterItemConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1283,7 +1285,7 @@ type OpenapiClusterItemStatusConnectionStringsStandard struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -1357,7 +1359,7 @@ type OpenapiClusterItemStatusConnectionStringsVpcPeering struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -1432,7 +1434,7 @@ type OpenapiClusterItemStatusNodeMap struct {
 	Tiflash []*OpenapiClusterItemStatusNodeMapTiflashItems0 `json:"tiflash"`
 
 	// TiKV node map.
-	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
+	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C32G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
 	// Required: true
 	Tikv []*OpenapiClusterItemStatusNodeMapTikvItems0 `json:"tikv"`
 }
@@ -1889,7 +1891,7 @@ type OpenapiClusterItemStatusNodeMapTikvItems0 struct {
 	NodeName string `json:"node_name,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The RAM size of a node in the cluster. If the `cluster_type` is `"DEVELOPER"`, `ram_bytes` is always 0.

--- a/models/openapi_cluster_item_status.go
+++ b/models/openapi_cluster_item_status.go
@@ -378,7 +378,7 @@ type OpenapiClusterItemStatusConnectionStringsStandard struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -452,7 +452,7 @@ type OpenapiClusterItemStatusConnectionStringsVpcPeering struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -527,7 +527,7 @@ type OpenapiClusterItemStatusNodeMap struct {
 	Tiflash []*OpenapiClusterItemStatusNodeMapTiflashItems0 `json:"tiflash"`
 
 	// TiKV node map.
-	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
+	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C32G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
 	// Required: true
 	Tikv []*OpenapiClusterItemStatusNodeMapTikvItems0 `json:"tikv"`
 }
@@ -984,7 +984,7 @@ type OpenapiClusterItemStatusNodeMapTikvItems0 struct {
 	NodeName string `json:"node_name,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The RAM size of a node in the cluster. If the `cluster_type` is `"DEVELOPER"`, `ram_bytes` is always 0.

--- a/models/openapi_cluster_node_map.go
+++ b/models/openapi_cluster_node_map.go
@@ -31,7 +31,7 @@ type OpenapiClusterNodeMap struct {
 	Tiflash []*OpenapiClusterNodeMapTiflashItems0 `json:"tiflash"`
 
 	// TiKV node map.
-	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
+	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C32G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
 	// Required: true
 	Tikv []*OpenapiClusterNodeMapTikvItems0 `json:"tikv"`
 }
@@ -488,7 +488,7 @@ type OpenapiClusterNodeMapTikvItems0 struct {
 	NodeName string `json:"node_name,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The RAM size of a node in the cluster. If the `cluster_type` is `"DEVELOPER"`, `ram_bytes` is always 0.

--- a/models/openapi_get_cluster_config.go
+++ b/models/openapi_get_cluster_config.go
@@ -131,7 +131,7 @@ func (m *OpenapiGetClusterConfig) UnmarshalBinary(b []byte) error {
 }
 
 // OpenapiGetClusterConfigComponents The components of the cluster.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 //
 // swagger:model OpenapiGetClusterConfigComponents
 type OpenapiGetClusterConfigComponents struct {
@@ -335,7 +335,7 @@ type OpenapiGetClusterConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -421,7 +421,7 @@ type OpenapiGetClusterConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -526,7 +526,7 @@ type OpenapiGetClusterConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/models/openapi_list_clusters_of_project_resp.go
+++ b/models/openapi_list_clusters_of_project_resp.go
@@ -154,8 +154,10 @@ type OpenapiListClustersOfProjectRespItemsItems0 struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 
 	// The cluster type:
-	// - `"DEVELOPER"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
-	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.
+	// - `"DEVELOPER"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
+	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster
+	//
+	// **Warning:** `"DEVELOPER"` will soon be changed to `"SERVERLESS"` to represent Serverless Tier clusters.
 	// Example: DEDICATED
 	// Enum: [DEDICATED DEVELOPER]
 	ClusterType string `json:"cluster_type,omitempty"`
@@ -449,7 +451,7 @@ func (m *OpenapiListClustersOfProjectRespItemsItems0) UnmarshalBinary(b []byte) 
 }
 
 // OpenapiListClustersOfProjectRespItemsItems0Config The configuration of the cluster.
-// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}},"port":4000}
+// Example: {"components":{"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}},"port":4000}
 //
 // swagger:model OpenapiListClustersOfProjectRespItemsItems0Config
 type OpenapiListClustersOfProjectRespItemsItems0Config struct {
@@ -566,7 +568,7 @@ func (m *OpenapiListClustersOfProjectRespItemsItems0Config) UnmarshalBinary(b []
 }
 
 // OpenapiListClustersOfProjectRespItemsItems0ConfigComponents The components of the cluster.
-// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C64G","storage_size_gib":1024}}
+// Example: {"tidb":{"node_quantity":2,"node_size":"8C16G"},"tikv":{"node_quantity":3,"node_size":"8C32G","storage_size_gib":1024}}
 //
 // swagger:model OpenapiListClustersOfProjectRespItemsItems0ConfigComponents
 type OpenapiListClustersOfProjectRespItemsItems0ConfigComponents struct {
@@ -770,7 +772,7 @@ type OpenapiListClustersOfProjectRespItemsItems0ConfigComponentsTidb struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -856,7 +858,7 @@ type OpenapiListClustersOfProjectRespItemsItems0ConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -961,7 +963,7 @@ type OpenapiListClustersOfProjectRespItemsItems0ConfigComponentsTikv struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`
@@ -1406,7 +1408,7 @@ type OpenapiListClustersOfProjectRespItemsItems0StatusConnectionStringsStandard 
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -1480,7 +1482,7 @@ type OpenapiListClustersOfProjectRespItemsItems0StatusConnectionStringsVpcPeerin
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024
@@ -1555,7 +1557,7 @@ type OpenapiListClustersOfProjectRespItemsItems0StatusNodeMap struct {
 	Tiflash []*OpenapiListClustersOfProjectRespItemsItems0StatusNodeMapTiflashItems0 `json:"tiflash"`
 
 	// TiKV node map.
-	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
+	// Example: [{"availability_zone":"us-west-2a","node_name":"tikv-0","node_size":"8C32G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2b","node_name":"tikv-1","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8},{"availability_zone":"us-west-2c","node_name":"tikv-2","node_size":"8C64G","ram_bytes":"68719476736","status":"NODE_STATUS_AVAILABLE","storage_size_gib":1024,"vcpu_num":8}]
 	// Required: true
 	Tikv []*OpenapiListClustersOfProjectRespItemsItems0StatusNodeMapTikvItems0 `json:"tikv"`
 }
@@ -2012,7 +2014,7 @@ type OpenapiListClustersOfProjectRespItemsItems0StatusNodeMapTikvItems0 struct {
 	NodeName string `json:"node_name,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The RAM size of a node in the cluster. If the `cluster_type` is `"DEVELOPER"`, `ram_bytes` is always 0.

--- a/models/openapi_list_provider_regions_item.go
+++ b/models/openapi_list_provider_regions_item.go
@@ -31,8 +31,10 @@ type OpenapiListProviderRegionsItem struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 
 	// The cluster type.
-	// - `"DEVELOPER"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
+	// - `"DEVELOPER"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
 	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster
+	//
+	// **Warning:** `"DEVELOPER"` will soon be changed to `"SERVERLESS"` to represent Serverless Tier clusters.
 	// Example: DEDICATED
 	// Enum: [DEDICATED DEVELOPER]
 	ClusterType string `json:"cluster_type,omitempty"`
@@ -710,7 +712,7 @@ type OpenapiListProviderRegionsItemTikvItems0 struct {
 	NodeQuantityRange *OpenapiListProviderRegionsItemTikvItems0NodeQuantityRange `json:"node_quantity_range,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// storage size gib range

--- a/models/openapi_list_provider_regions_resp.go
+++ b/models/openapi_list_provider_regions_resp.go
@@ -24,7 +24,7 @@ import (
 type OpenapiListProviderRegionsResp struct {
 
 	// Items of provider regions.
-	// Example: [{"cloud_provider":"AWS","cluster_type":"DEDICATED","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"8C16G"}],"tiflash":[{"node_quantity_range":{"min":0,"step":1},"node_size":"8C64G","storage_size_gib_range":{"max":2048,"min":500}}],"tikv":[{"node_quantity_range":{"min":3,"step":3},"node_size":"8C64G","storage_size_gib_range":{"max":4096,"min":500}}]},{"cloud_provider":"AWS","cluster_type":"DEVELOPER","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0"}],"tiflash":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}],"tikv":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}]}]
+	// Example: [{"cloud_provider":"AWS","cluster_type":"DEDICATED","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"8C16G"}],"tiflash":[{"node_quantity_range":{"min":0,"step":1},"node_size":"8C64G","storage_size_gib_range":{"max":2048,"min":500}}],"tikv":[{"node_quantity_range":{"min":3,"step":3},"node_size":"8C32G","storage_size_gib_range":{"max":4096,"min":500}}]},{"cloud_provider":"AWS","cluster_type":"DEVELOPER","region":"us-west-2","tidb":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0"}],"tiflash":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}],"tikv":[{"node_quantity_range":{"min":1,"step":1},"node_size":"Shared0","storage_size_gib_range":{"max":1,"min":1}}]}]
 	Items []*OpenapiListProviderRegionsRespItemsItems0 `json:"items"`
 }
 
@@ -135,8 +135,10 @@ type OpenapiListProviderRegionsRespItemsItems0 struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 
 	// The cluster type.
-	// - `"DEVELOPER"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster
+	// - `"DEVELOPER"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster
 	// - `"DEDICATED"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster
+	//
+	// **Warning:** `"DEVELOPER"` will soon be changed to `"SERVERLESS"` to represent Serverless Tier clusters.
 	// Example: DEDICATED
 	// Enum: [DEDICATED DEVELOPER]
 	ClusterType string `json:"cluster_type,omitempty"`
@@ -814,7 +816,7 @@ type OpenapiListProviderRegionsRespItemsItems0TikvItems0 struct {
 	NodeQuantityRange *OpenapiListProviderRegionsRespItemsItems0TikvItems0NodeQuantityRange `json:"node_quantity_range,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// storage size gib range

--- a/models/openapi_standard_connection.go
+++ b/models/openapi_standard_connection.go
@@ -26,7 +26,7 @@ type OpenapiStandardConnection struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024

--- a/models/openapi_ti_d_b_component.go
+++ b/models/openapi_ti_d_b_component.go
@@ -32,7 +32,7 @@ type OpenapiTiDBComponent struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiDB of an existing cluster.
+	// - You cannot decrease `node_size` for TiDB.
 	// Example: 8C16G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/models/openapi_ti_flash_component.go
+++ b/models/openapi_ti_flash_component.go
@@ -35,7 +35,7 @@ type OpenapiTiFlashComponent struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
+	// - You cannot decrease `node_size` for TiFlash.
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/models/openapi_ti_k_v_component.go
+++ b/models/openapi_ti_k_v_component.go
@@ -35,7 +35,7 @@ type OpenapiTiKVComponent struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiKV of an existing cluster.
+	// - You cannot decrease `node_size` for TiKV
 	// Example: 8C64G
 	// Required: true
 	NodeSize *string `json:"node_size"`

--- a/models/openapi_ti_k_v_node_map.go
+++ b/models/openapi_ti_k_v_node_map.go
@@ -29,7 +29,7 @@ type OpenapiTiKVNodeMap struct {
 	NodeName string `json:"node_name,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The RAM size of a node in the cluster. If the `cluster_type` is `"DEVELOPER"`, `ram_bytes` is always 0.

--- a/models/openapi_ti_k_v_profile.go
+++ b/models/openapi_ti_k_v_profile.go
@@ -22,7 +22,7 @@ type OpenapiTiKVProfile struct {
 	NodeQuantityRange *OpenapiTiKVProfileNodeQuantityRange `json:"node_quantity_range,omitempty"`
 
 	// The size of the TiKV component in the cluster.
-	// Example: 8C64G
+	// Example: 8C32G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// storage size gib range

--- a/models/openapi_update_cluster_components.go
+++ b/models/openapi_update_cluster_components.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // OpenapiUpdateClusterComponents openapi update cluster components
@@ -203,30 +202,23 @@ type OpenapiUpdateClusterComponentsTidb struct {
 
 	// The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	// Example: 3
-	// Required: true
-	NodeQuantity *int32 `json:"node_quantity"`
+	NodeQuantity int32 `json:"node_quantity,omitempty"`
+
+	// The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiDB.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C32G
+	NodeSize string `json:"node_size,omitempty"`
 }
 
 // Validate validates this openapi update cluster components tidb
 func (m *OpenapiUpdateClusterComponentsTidb) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateNodeQuantity(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *OpenapiUpdateClusterComponentsTidb) validateNodeQuantity(formats strfmt.Registry) error {
-
-	if err := validate.Required("tidb"+"."+"node_quantity", "body", m.NodeQuantity); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -274,8 +266,9 @@ type OpenapiUpdateClusterComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
-	// Example: 8C64G
+	// - You cannot decrease node size for TiFlash.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C128G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
@@ -283,7 +276,7 @@ type OpenapiUpdateClusterComponentsTiflash struct {
 	// **Limitations**:
 	// - You cannot decrease storage size for TiFlash.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 
@@ -328,12 +321,24 @@ type OpenapiUpdateClusterComponentsTikv struct {
 	// Example: 6
 	NodeQuantity int32 `json:"node_quantity,omitempty"`
 
+	// The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiKV.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C64G
+	NodeSize string `json:"node_size,omitempty"`
+
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	//
 	// **Limitations**:
 	// - You cannot decrease storage size for TiKV.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 

--- a/models/openapi_update_cluster_config.go
+++ b/models/openapi_update_cluster_config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // OpenapiUpdateClusterConfig UpdateClusterComponents
@@ -302,30 +301,23 @@ type OpenapiUpdateClusterConfigComponentsTidb struct {
 
 	// The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	// Example: 3
-	// Required: true
-	NodeQuantity *int32 `json:"node_quantity"`
+	NodeQuantity int32 `json:"node_quantity,omitempty"`
+
+	// The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiDB.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C32G
+	NodeSize string `json:"node_size,omitempty"`
 }
 
 // Validate validates this openapi update cluster config components tidb
 func (m *OpenapiUpdateClusterConfigComponentsTidb) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateNodeQuantity(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *OpenapiUpdateClusterConfigComponentsTidb) validateNodeQuantity(formats strfmt.Registry) error {
-
-	if err := validate.Required("components"+"."+"tidb"+"."+"node_quantity", "body", m.NodeQuantity); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -373,8 +365,9 @@ type OpenapiUpdateClusterConfigComponentsTiflash struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
-	// Example: 8C64G
+	// - You cannot decrease node size for TiFlash.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C128G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
@@ -382,7 +375,7 @@ type OpenapiUpdateClusterConfigComponentsTiflash struct {
 	// **Limitations**:
 	// - You cannot decrease storage size for TiFlash.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 
@@ -427,12 +420,24 @@ type OpenapiUpdateClusterConfigComponentsTikv struct {
 	// Example: 6
 	NodeQuantity int32 `json:"node_quantity,omitempty"`
 
+	// The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiKV.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C64G
+	NodeSize string `json:"node_size,omitempty"`
+
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	//
 	// **Limitations**:
 	// - You cannot decrease storage size for TiKV.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 

--- a/models/openapi_update_ti_d_b_component.go
+++ b/models/openapi_update_ti_d_b_component.go
@@ -8,10 +8,8 @@ package models
 import (
 	"context"
 
-	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // OpenapiUpdateTiDBComponent openapi update ti d b component
@@ -21,30 +19,23 @@ type OpenapiUpdateTiDBComponent struct {
 
 	// The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	// Example: 3
-	// Required: true
-	NodeQuantity *int32 `json:"node_quantity"`
+	NodeQuantity int32 `json:"node_quantity,omitempty"`
+
+	// The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiDB.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C32G
+	NodeSize string `json:"node_size,omitempty"`
 }
 
 // Validate validates this openapi update ti d b component
 func (m *OpenapiUpdateTiDBComponent) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateNodeQuantity(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *OpenapiUpdateTiDBComponent) validateNodeQuantity(formats strfmt.Registry) error {
-
-	if err := validate.Required("node_quantity", "body", m.NodeQuantity); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/models/openapi_update_ti_flash_component.go
+++ b/models/openapi_update_ti_flash_component.go
@@ -31,8 +31,9 @@ type OpenapiUpdateTiFlashComponent struct {
 	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
 	//
 	// **Limitations**:
-	// - You cannot modify `node_size` for TiFlash of an existing cluster.
-	// Example: 8C64G
+	// - You cannot decrease node size for TiFlash.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C128G
 	NodeSize string `json:"node_size,omitempty"`
 
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
@@ -40,7 +41,7 @@ type OpenapiUpdateTiFlashComponent struct {
 	// **Limitations**:
 	// - You cannot decrease storage size for TiFlash.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 

--- a/models/openapi_update_ti_k_v_component.go
+++ b/models/openapi_update_ti_k_v_component.go
@@ -25,12 +25,24 @@ type OpenapiUpdateTiKVComponent struct {
 	// Example: 6
 	NodeQuantity int32 `json:"node_quantity,omitempty"`
 
+	// The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
+	//
+	// **Additional combination rules**:
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
+	// - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
+	//
+	// **Limitations**:
+	// - You cannot decrease node size for TiKV.
+	// - For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size).
+	// Example: 16C64G
+	NodeSize string `json:"node_size,omitempty"`
+
 	// The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).
 	//
 	// **Limitations**:
 	// - You cannot decrease storage size for TiKV.
 	// - If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again.
-	// Example: 1024
+	// Example: 2048
 	StorageSizeGib int32 `json:"storage_size_gib,omitempty"`
 }
 

--- a/models/openapi_v_p_c_peering_connection.go
+++ b/models/openapi_v_p_c_peering_connection.go
@@ -26,7 +26,7 @@ type OpenapiVPCPeeringConnection struct {
 	// The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.
 	//
 	// **Limitations**:
-	// - For a Developer Tier cluster, only port `4000` is available.
+	// - For a Serverless Tier cluster, only port `4000` is available.
 	// Example: 4000
 	// Maximum: 65535
 	// Minimum: 1024

--- a/tidbcloud-oas.json
+++ b/tidbcloud-oas.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "TiDB Cloud API",
-    "description": "TiDB Cloud API is still in beta and only available upon request. You can apply for API access by submitting a request:\n\n- Click **Help** in the lower-right corner of [TiDB Cloud console](https://tidbcloud.com).\n- In the dialog, fill in \"Apply for TiDB Cloud API\" in the **Description** field and click **Send**.\n\nYou will receive an email for notification when the API is available for you.\n\n# Overview\n\nThe TiDB Cloud API is a [REST interface](https://en.wikipedia.org/wiki/Representational_state_transfer) that provides you with programmatic access to manage administrative objects within TiDB Cloud. Through this API, you can manage resources automatically and efficiently:\n\n* Projects\n* Clusters\n* Backups\n* Restores\n\nThe API has the following features:\n\n- **JSON entities.** All entities are expressed in JSON.\n- **HTTPS-only.** You can only access the API via HTTPS, ensuring all the data sent over the network is encrypted with TLS.\n- **Key-based access and digest authentication.** Before you access TiDB Cloud API, you must generate an API key. All requests are authenticated through [HTTP Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication), ensuring the API key is never sent over the network.\n\n# Get Started\n\nThis guide helps you make your first API call to TiDB Cloud API. You'll learn how to authenticate a request, build a request, and interpret the response. The [List all accessible projects](#tag/Project/operation/ListProjects) endpoint is used in this guide as an example.\n\n## Prerequisites\n\nTo complete this guide, you need to perform the following tasks:\n\n- Create a [TiDB Cloud account](https://tidbcloud.com/free-trial)\n- Install [curl](https://curl.se/)\n\n## Step 1. Create an API key\n\nTo create an API key, log in to your TiDB Cloud console. Navigate to the **Organization Settings** page, and create an API key.\n\nAn API key contains a public key and a private key. Copy and save them in a secure location. You will need to use the API key later in this guide.\n\nFor more details about creating API key, refer to [API Key Management](#section/Authentication/API-Key-Management).\n\n## Step 2. Make your first API call\n\n### Build an API call\n\nTiDB Cloud API call have the following components:\n\n- **A host.** The host for TiDB Cloud API is <https://api.tidbcloud.com>.\n- **An API Key**. The public key and the private key are required for authentication.\n- **A request.** When submitting data to a resource via `POST`, `PATCH`, or `PUT`, you must submit your payload in JSON.\n\nIn this guide, you call the [List all accessible projects](#tag/Project/operation/ListProjects) endpoint. For the detailed description of the endpoint, see the [API reference](#tag/Project/operation/ListProjects).\n\n### Call an API endpoint\n\nTo get all projects in your organization, run the following command in your terminal. Remember to change `YOUR_PUBLIC_KEY` to your public key and `YOUR_PRIVATE_KEY` to your private key.\n\n```shell\ncurl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request GET \\\n  --url https://api.tidbcloud.com/api/v1beta/projects\n```\n\n## Step 3. Check the response\n\nAfter making the API call, if the status code in response is `200` and you see details about all the projects in your organization, your request is successful. Here is an example of a successful response.\n\n```log\n{\n  \"items\": [\n    {\n      \"id\": \"{project_id}\",\n      \"org_id\": \"{org_id}\",\n      \"name\": \"MyProject\",\n      \"cluster_count\": 3,\n      \"user_count\": 1,\n      \"create_timestamp\": \"1652407748\"\n    }\n  ],\n  \"total\": 1\n}\n```\n\nIf your API call is not successful, you will receive a status code other than `200` and the response looks similar to the following example. To troubleshoot the failed call, you can check the `message` in the response.\n\n```log\n{\n  \"code\": 49900001,\n  \"message\": \"public_key not found\",\n  \"details\": []\n}\n```\n\n## Code samples\n\nThis section walks you through the quickest way to get started with TiDB Cloud API using programming languages. In these examples, you will learn how to use Python to create a cluster, backup and restore data, and scale out a cluster.\n\nYou can view the [full code examples](https://github.com/tidbcloud/tidbcloud-api-samples) of Python and Golang on GitHub or clone the repository to your local machine.\n\n```git\ngit clone https://github.com/tidbcloud/tidbcloud-api-samples.git\n```\n\n### Create and connect to a TiDB cluster\n\nThe following code examples show how to create a TiDB cluster and connect to the cluster. The whole process takes five steps:\n\n1. Get all projects.\n2. Get the cloud providers, regions and specifications.\n3. Create a cluster in your specified project.\n4. Get the new cluster information.\n5. Connect to the cluster using a MySQL client.\n\n#### Step 1: Get all projects\n\nBefore you create a cluster, you need to get the ID of the project that you want to create a cluster in.\n\nTo view the information of all available projects, you can use the [List all accessible projects](#tag/Project/operation/ListProjects) endpoint.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_all_projects(public_key: str, private_key: str) -> dict:\n    \"\"\"\n    Get all projects\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :return: Projects detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects\"\n    resp = requests.get(url=url, auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY and YOUR_PRIVATE_KEY\n    project = get_all_projects(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\")\n    print(project)\n```\n\nFor more details about the request and response, see [List all accessible projects](#tag/Project/operation/ListProjects).\n\n#### Step 2: Get the cloud providers, regions and specifications\n\nBefore you create a cluster, you need to get the list of available cloud providers, regions, and specifications.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_provider_regions_specifications(public_key: str, private_key: str) -> dict:\n    \"\"\"\n    Get cloud providers, regions and available specifications.\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :return: List the cloud providers, regions and available specifications.\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/clusters/provider/regions\"\n    resp = requests.get(url=url, auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY and YOUR_PRIVATE_KEY\n    provider_regions_specifications = get_provider_regions_specifications(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\")\n    print(provider_regions_specifications)\n```\n\nFor more details about the request and response, see [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n#### Step 3: Create a cluster in your specified project and cloud provider\n\nThe following example uses the [Create a cluster](#tag/Cluster/operation/CreateCluster) endpoint to create a Dedicated Tier cluster. A configuration example is provided in the code; you can replace the parameters using the information you get in the previous two steps.\n\n```python\nimport requests\nimport time\nimport json\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef create_dedicated_cluster(public_key: str, private_key: str, project_id: str) -> dict:\n    \"\"\"\n    Create a dedicated cluster in your specified project.\n    `data_config` below is a demo. You should fill in the field according to\n    your own situation\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :return: Dedicated cluster id\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters\"\n    ts = int(time.time())\n    data_config = \\\n        {\n            \"name\": f\"tidbcloud-sample-{ts}\",\n            \"cluster_type\": \"DEDICATED\",\n            \"cloud_provider\": \"AWS\",\n            \"region\": \"us-west-2\",\n            \"config\":\n                {\n                    \"root_password\": \"input_your_password\",\n                    \"port\": 4000,\n                    \"components\":\n                        {\n                            \"tidb\":\n                                {\n                                    \"node_size\": \"8C16G\",\n                                    \"node_quantity\": 1\n                                },\n                            \"tikv\":\n                                {\"node_size\": \"8C32G\",\n                                 \"storage_size_gib\": 500,\n                                 \"node_quantity\": 3\n                                 }\n                        },\n                    \"ip_access_list\":\n                        [\n                            {\n                                \"cidr\": \"0.0.0.0/0\",\n                                \"description\": \"Allow Access from Anywhere.\"\n                            }\n                        ]\n\n                }\n        }\n    data_config_json = json.dumps(data_config)\n    resp = requests.post(url=url,\n                         auth=HTTPDigestAuth(public_key, private_key),\n                         data=data_config_json)\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY and YOUR_PROJECT_ID\n    cluster = create_dedicated_cluster(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\")\n    print(cluster)\n```\n\nThis request returns the ID of the cluster that you just created. For more details about the request and response, see [Create a cluster](#tag/Cluster/operation/CreateCluster).\n\n#### Step 4: Get the new cluster information\n\nAfter you successfully create a cluster, you can use the [Get cluster by ID](#tag/Cluster/operation/GetCluster) endpoint to get the information of the cluster.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_cluster_by_id(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Get the cluster detail.\n    You will get `connection_strings` from the response after the cluster's status is`AVAILABLE`.\n    Then, you can connect to TiDB using the default user, host, and port in `connection_strings`\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :return: The cluster detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    resp = requests.get(url=url,\n                        auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    cluster = get_cluster_by_id(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                       \"{YOUR_CLUSTER_ID}\")\n    print(cluster)\n```\n\nIn the response, you can see the `connection_strings` field, which will be used later for connecting to the TiDB cluster. However, if your cluster status is `CREATING`, the `connection_strings` field might be empty. In such cases, you need to wait a while until the cluster status becomes `AVAILABLE` so that you can move on to the next step.\n\nFor more details about the request and response, see [Get a cluster by ID](#tag/Cluster/operation/GetCluster).\n\n#### Step 5: Connect to the cluster using a MySQL client\n\nAfter the cluster becomes `AVAILABLE`, you can get the connection strings. With the connection strings, you can connect to the cluster using a MySQL client.\n\nThe connection strings contain three fields:\n\n- `default_user`, the username you use to connect to TiDB.\n- `standard` connection string. In this guide, you'll use the `standard` connection.\n- `vpc_peering` connection string.\n\nThe `standard` connection string contains a `host` and a `port`. In the following command, replace `${default_user}` and `${host}` with the actual values in the connection strings. Run the command to connect to the TiDB cluster.\n\n```shell\nmysql --connect-timeout 15 -u ${default_user} -h ${host} -P 4000 -D test -p\n```\n\nFor more details on connection, see [Connect to TiDB Cluster](https://docs.pingcap.com/tidbcloud/connect-to-tidb-cluster).\n\n### Manage backups for your clusters\n\nThe following example shows how to create a manual backup and restore the last backup data to a new cluster.\n\n#### Step 1: Create a manual backup\n\nTo create a manual backup, you can use the [Create a backup for a cluster](#tag/Backup/operation/CreateBackup) endpoint.\n\n```python\nimport requests\nimport json\nimport datetime\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef create_manual_backup(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Create manual backup\n    `data_for_backup` below is a demo. You should fill in the field according to\n    your own situation\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The dedicated cluster id\n    :return: The backup id\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}/backups\"\n    cur_date = datetime.datetime.now().strftime(\"%Y-%m-%d\")\n    data_for_backup = {\"name\": f\"tidbcloud-backup-{cur_date}\", \"description\": f\"tidbcloud-backup-{cur_date}\"}\n    data_for_backup_json = json.dumps(data_for_backup)\n    resp = requests.post(url=url,\n                         data=data_for_backup_json,\n                         auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    backup = create_manual_backup(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                  \"{YOUR_CLUSTER_ID}\")\n    print(backup)\n```\n\n#### Step 2: Restore the last backup data to a new cluster\n\nTo restore the last backup data to a new cluster, you can use the [Create a restore task](#tag/Restore/operation/CreateRestoreTask) endpoint.\n\n```python\nimport requests\nimport json\nimport datetime\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef create_restore_task(public_key: str, private_key: str, project_id: str, back_up_id: str) -> dict:\n    \"\"\"\n    Create restore task\n    `data_for_restore` below is a demo. You should fill in the field according to\n    your own situation\n    :param private_key: Your public key\n    :param public_key: Your private key\n    :param project_id: The project id\n    :param back_up_id: The backup id\n    :return: The restore task id\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/restores\"\n    cur_date = datetime.datetime.now().strftime(\"%Y-%m-%d\")\n    data_for_restore = \\\n        {\n            \"backup_id\": f\"{back_up_id}\",\n            \"name\": f\"tidbcloud-restore-{cur_date}\",\n            \"config\":\n                {\n                    \"root_password\": \"input_your_password\",\n                    \"port\": 4000,\n                    \"components\":\n                        {\n                            \"tidb\":\n                                {\n                                    \"node_size\": \"8C16G\",\n                                    \"node_quantity\": 1\n                                },\n                            \"tikv\":\n                                {\n                                    \"node_size\": \"8C32G\",\n                                    \"storage_size_gib\": 500,\n                                    \"node_quantity\": 3\n                                }\n                        },\n                    \"ip_access_list\":\n                        [\n                            {\n                                \"cidr\": \"0.0.0.0/0\",\n                                \"description\": \"Allow Access from Anywhere.\"\n                            }\n                        ]\n\n                }\n        }\n    data_for_restore_json = json.dumps(data_for_restore)\n    resp = requests.post(url=url,\n                         auth=HTTPDigestAuth(public_key, private_key),\n                         data=data_for_restore_json)\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_BACKUP_ID\n    restore = create_restore_task(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                  \"{YOUR_BACKUP_ID}\")\n    print(restore)\n```\n\n#### Step 3: Get the restored cluster information\n\nTo get the information of the restored cluster, you can use the [Get a cluster by ID](#tag/Cluster/operation/GetCluster) endpoint.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_cluster_by_id(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Get the cluster detail.\n    You will get `connection_strings` from the response after the cluster's status is`AVAILABLE`.\n    Then, you can connect to TiDB using the default user, host, and port in `connection_strings`\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :return: The cluster detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    resp = requests.get(url=url,\n                        auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    cluster = get_cluster_by_id(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                       \"{YOUR_CLUSTER_ID}\")\n    print(cluster)\n```\n\n### Scale out one TiFlash node for an existing cluster\n\nThe following example shows how to scale out one TiFlash node for an existing cluster.\n\n#### Step 1: Add one TiFlash node for the specified cluster\n\nTo add a TiFlash node for the Dedicated Tier cluster, you can use the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n\n```python\nimport requests\nimport json\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef modify_cluster(public_key: str, private_key: str, project_id: str, cluster_id: str, tiflash_num: int) -> dict:\n    \"\"\"\n    Add one TiFlash node for specified cluster\n    If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n    `data_add_tiflash` below is a demo. You should fill in the field according to\n    your own situation\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :param tiflash_num: The tiflash num\n    :return: If success, return None. Else, return message\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    data_add_tiflash = \\\n        {\n            \"config\":\n                {\n                    \"components\":\n                        {\n                            \"tidb\":\n                                {\n                                    \"node_quantity\": 1\n                                },\n                            \"tikv\":\n                                {\n                                    \"node_quantity\": 3\n                                },\n                            \"tiflash\":\n                                {\n                                    \"node_quantity\": f\"{tiflash_num}\",\n                                    \"node_size\": \"8C64G\",\n                                    \"storage_size_gib\": 500\n                                }\n                        }\n                }\n        }\n    data_add_tiflash_json = json.dumps(data_add_tiflash)\n    resp = requests.patch(url=url,\n                          auth=HTTPDigestAuth(public_key, private_key),\n                          data=data_add_tiflash_json)\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID, YOUR_CLUSTER_ID and MODIFY_TIFLASH_NUM\n    modify_cluster(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                   \"{YOUR_CLUSTER_ID}\", \"{MODIFY_TIFLASH_NUM}\")\n```\n\n#### Step 2: View the scale-out progress\n\nTo view the scale-out progress, you can use the [Get a cluster by ID](#tag/Cluster/operation/GetCluster) endpoint.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_cluster_by_id(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Get the cluster detail.\n    You will get `connection_strings` from the response after the cluster's status is`AVAILABLE`.\n    Then, you can connect to TiDB using the default user, host, and port in `connection_strings`\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :return: The cluster detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    resp = requests.get(url=url,\n                        auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    cluster = get_cluster_by_id(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                       \"{YOUR_CLUSTER_ID}\")\n    print(cluster)\n```\n\n# Authentication\n\nThe TiDB Cloud API uses [HTTP Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication). It protects your private key from being sent over the network. For more details about HTTP Digest Authentication, refer to the [IETF RFC](https://datatracker.ietf.org/doc/html/rfc7616).\n\n## API Key Overview\n\n- The API key contains a public key and a private key, which act as the username and password required in the HTTP Digest Authentication. The private key only displays upon the key creation.\n- The API key belongs to your organization and acts as the `Owner` role. You can check [permissions of owner](https://docs.pingcap.com/tidbcloud/manage-user-access#configure-member-roles).\n- You must provide the correct API key in every request. Otherwise, the TiDB Cloud responds with a `401` error.\n\n## API Key Management\n\n### Create an API Key\n\nOnly the **owner** of an organization can create an API key.\n\nTo create an API key in an organization, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab and then click **Create API Key**.\n4. Enter a description for your API key. The role of the API key is always `Owner` currently.\n5. Click **Next**. Copy and save the public key and the private key.\n6. Make sure that you have copied and saved the private key in a secure location. The private key only displays upon the creation. After leaving this page, you will not be able to get the full private key again.\n7. Click **Done**.\n\n### View Details of an API Key\n\nTo view details of an API key, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab.\n4. You can view the details of the API keys in the menu.\n\n### Edit an API Key\n\nOnly the **owner** of an organization can modify an API key.\n\nTo edit an API key in an organization, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab.\n4. Click **Edit** in the API key row that you want to change.\n4. You can update the API key description.\n5. Click **Done**.\n\n### Delete an API key\n\nOnly the **owner** of an organization can delete an API key.\n\nTo delete an API key in an organization, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab.\n4. Click **Delete** in the API key row that you want to delete.\n5. Click **I understand the consequences, delete this API Key.**\n\n# Rate Limiting\n\n\nThe TiDB Cloud API allows up to 100 requests per minute per API key. If you exceed the rate limit, the API returns a `429` error.\n\nEach API request returns the following headers about the limit.\n\n- `X-Ratelimit-Limit-Minute`: The number of requests allowed per minute. It is 100 currently.\n- `X-Ratelimit-Remaining-Minute`: The number of remaining requests in the current minute. When it reaches `0`, the API returns a `429` error and indicates that you exceed the rate limit.\n- `X-Ratelimit-Reset`: The time in seconds at which the current rate limit resets.\n\nIf you exceed the rate limit, an error response returns like this.\n\n```\n> HTTP/2 429\n> date: Fri, 22 Jul 2022 05:28:37 GMT\n> content-type: application/json\n> content-length: 66\n> x-ratelimit-reset: 23\n> x-ratelimit-remaining-minute: 0\n> x-ratelimit-limit-minute: 100\n> x-kong-response-latency: 2\n> server: kong/2.8.1\n\n> {\"details\":[],\"code\":49900007,\"message\":\"API rate limit exceeded\"}\n```\n\n# API Changelog\n\nThis changelog lists all changes to the TiDB Cloud API.\n\n<!-- In reverse chronological order -->\n\n## 20220906\n\n- Add a `config.components.tikv.storage_size_gib` field to the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n- Modify the `config.components.tikv.node_quantity` and `config.components.tiflash.node_quantity` fields from `required` to `optional` for the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n- Remove the \"Can not modify `storage_size_gib` of an existing cluster\" limitation of the `config.components.tiflash.storage_size_gib` field for the [Create a cluster](#tag/Cluster/operation/CreateCluster) and [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoints.\n\n## 20220823\n\n- Add a `config.paused` field to the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n- Add two cluster statuses: `\"IMPORTING\"` and `\"UNAVAILABLE\"`.\n\n## 20220809\n\n- Initial release of the TiDB Cloud API (v1beta) in private beta, including the following resources and endpoints:\n\n    - Project:\n\n        - [List all accessible projects](#tag/Project/operation/ListProjects)\n\n    - Cluster:\n        - [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions)\n        - [List all clusters in a project](/#tag/Cluster/operation/ListClustersOfProject)\n        - [Create a cluster](#tag/Cluster/operation/CreateCluster)\n        - [Get a cluster by ID](#tag/Cluster/operation/GetCluster)\n        - [Delete a cluster](#tag/Cluster/operation/DeleteCluster)\n        - [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster)\n    - Backup:\n        - [List all backups for a cluster](#tag/Backup/operation/ListBackUpOfCluster)\n        - [Create a backup for a cluster](#tag/Backup/operation/CreateBackup)\n        - [Get a backup for a cluster](#tag/Backup/operation/GetBackupOfCluster)\n        - [Delete a backup for a cluster](#tag/Backup/operation/DeleteBackup)\n    - Restore:\n        - [List the restore tasks in a project](#tag/Restore/operation/ListRestoreTasks)\n        - [Create a restore task](#tag/Restore/operation/CreateRestoreTask)\n        - [Get a restore task](#tag/Restore/operation/GetRestoreTask)\n",
+    "description": "*TiDB Cloud API is in beta.*\n\n# Overview\n\nThe TiDB Cloud API is a [REST interface](https://en.wikipedia.org/wiki/Representational_state_transfer) that provides you with programmatic access to manage administrative objects within TiDB Cloud. Through this API, you can manage resources automatically and efficiently:\n\n* Projects\n* Clusters\n* Backups\n* Restores\n\nThe API has the following features:\n\n- **JSON entities.** All entities are expressed in JSON.\n- **HTTPS-only.** You can only access the API via HTTPS, ensuring all the data sent over the network is encrypted with TLS.\n- **Key-based access and digest authentication.** Before you access TiDB Cloud API, you must generate an API key. All requests are authenticated through [HTTP Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication), ensuring the API key is never sent over the network.\n\n# Get Started\n\nThis guide helps you make your first API call to TiDB Cloud API. You'll learn how to authenticate a request, build a request, and interpret the response. The [List all accessible projects](#tag/Project/operation/ListProjects) endpoint is used in this guide as an example.\n\n## Prerequisites\n\nTo complete this guide, you need to perform the following tasks:\n\n- Create a [TiDB Cloud account](https://tidbcloud.com/free-trial)\n- Install [curl](https://curl.se/)\n\n## Step 1. Create an API key\n\nTo create an API key, log in to your TiDB Cloud console. Navigate to the **Organization Settings** page, and create an API key.\n\nAn API key contains a public key and a private key. Copy and save them in a secure location. You will need to use the API key later in this guide.\n\nFor more details about creating API key, refer to [API Key Management](#section/Authentication/API-Key-Management).\n\n## Step 2. Make your first API call\n\n### Build an API call\n\nTiDB Cloud API call have the following components:\n\n- **A host.** The host for TiDB Cloud API is <https://api.tidbcloud.com>.\n- **An API Key**. The public key and the private key are required for authentication.\n- **A request.** When submitting data to a resource via `POST`, `PATCH`, or `PUT`, you must submit your payload in JSON.\n\nIn this guide, you call the [List all accessible projects](#tag/Project/operation/ListProjects) endpoint. For the detailed description of the endpoint, see the [API reference](#tag/Project/operation/ListProjects).\n\n### Call an API endpoint\n\nTo get all projects in your organization, run the following command in your terminal. Remember to change `YOUR_PUBLIC_KEY` to your public key and `YOUR_PRIVATE_KEY` to your private key.\n\n```shell\ncurl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request GET \\\n  --url https://api.tidbcloud.com/api/v1beta/projects\n```\n\n## Step 3. Check the response\n\nAfter making the API call, if the status code in response is `200` and you see details about all the projects in your organization, your request is successful. Here is an example of a successful response.\n\n```log\n{\n  \"items\": [\n    {\n      \"id\": \"{project_id}\",\n      \"org_id\": \"{org_id}\",\n      \"name\": \"MyProject\",\n      \"cluster_count\": 3,\n      \"user_count\": 1,\n      \"create_timestamp\": \"1652407748\"\n    }\n  ],\n  \"total\": 1\n}\n```\n\nIf your API call is not successful, you will receive a status code other than `200` and the response looks similar to the following example. To troubleshoot the failed call, you can check the `message` in the response.\n\n```log\n{\n  \"code\": 49900001,\n  \"message\": \"public_key not found\",\n  \"details\": []\n}\n```\n\n## Code samples\n\nThis section walks you through the quickest way to get started with TiDB Cloud API using programming languages. In these examples, you will learn how to use Python to create a cluster, backup and restore data, and scale out a cluster.\n\nYou can view the [full code examples](https://github.com/tidbcloud/tidbcloud-api-samples) of Python and Golang on GitHub or clone the repository to your local machine.\n\n```git\ngit clone https://github.com/tidbcloud/tidbcloud-api-samples.git\n```\n\n### Create and connect to a TiDB cluster\n\nThe following code examples show how to create a TiDB cluster and connect to the cluster. The whole process takes five steps:\n\n1. Get all projects.\n2. Get the cloud providers, regions and specifications.\n3. Create a cluster in your specified project.\n4. Get the new cluster information.\n5. Connect to the cluster using a MySQL client.\n\n#### Step 1: Get all projects\n\nBefore you create a cluster, you need to get the ID of the project that you want to create a cluster in.\n\nTo view the information of all available projects, you can use the [List all accessible projects](#tag/Project/operation/ListProjects) endpoint.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_all_projects(public_key: str, private_key: str) -> dict:\n    \"\"\"\n    Get all projects\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :return: Projects detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects\"\n    resp = requests.get(url=url, auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY and YOUR_PRIVATE_KEY\n    project = get_all_projects(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\")\n    print(project)\n```\n\nFor more details about the request and response, see [List all accessible projects](#tag/Project/operation/ListProjects).\n\n#### Step 2: Get the cloud providers, regions and specifications\n\nBefore you create a cluster, you need to get the list of available cloud providers, regions, and specifications.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_provider_regions_specifications(public_key: str, private_key: str) -> dict:\n    \"\"\"\n    Get cloud providers, regions and available specifications.\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :return: List the cloud providers, regions and available specifications.\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/clusters/provider/regions\"\n    resp = requests.get(url=url, auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY and YOUR_PRIVATE_KEY\n    provider_regions_specifications = get_provider_regions_specifications(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\")\n    print(provider_regions_specifications)\n```\n\nFor more details about the request and response, see [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n#### Step 3: Create a cluster in your specified project and cloud provider\n\nThe following example uses the [Create a cluster](#tag/Cluster/operation/CreateCluster) endpoint to create a Dedicated Tier cluster. A configuration example is provided in the code; you can replace the parameters using the information you get in the previous two steps.\n\n```python\nimport requests\nimport time\nimport json\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef create_dedicated_cluster(public_key: str, private_key: str, project_id: str) -> dict:\n    \"\"\"\n    Create a dedicated cluster in your specified project.\n    `data_config` below is a demo. You should fill in the field according to\n    your own situation\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :return: Dedicated cluster id\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters\"\n    ts = int(time.time())\n    data_config = \\\n        {\n            \"name\": f\"tidbcloud-sample-{ts}\",\n            \"cluster_type\": \"DEDICATED\",\n            \"cloud_provider\": \"AWS\",\n            \"region\": \"us-west-2\",\n            \"config\":\n                {\n                    \"root_password\": \"input_your_password\",\n                    \"port\": 4000,\n                    \"components\":\n                        {\n                            \"tidb\":\n                                {\n                                    \"node_size\": \"8C16G\",\n                                    \"node_quantity\": 1\n                                },\n                            \"tikv\":\n                                {\"node_size\": \"8C32G\",\n                                 \"storage_size_gib\": 500,\n                                 \"node_quantity\": 3\n                                 }\n                        },\n                    \"ip_access_list\":\n                        [\n                            {\n                                \"cidr\": \"0.0.0.0/0\",\n                                \"description\": \"Allow Access from Anywhere.\"\n                            }\n                        ]\n\n                }\n        }\n    data_config_json = json.dumps(data_config)\n    resp = requests.post(url=url,\n                         auth=HTTPDigestAuth(public_key, private_key),\n                         data=data_config_json)\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY and YOUR_PROJECT_ID\n    cluster = create_dedicated_cluster(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\")\n    print(cluster)\n```\n\nThis request returns the ID of the cluster that you just created. For more details about the request and response, see [Create a cluster](#tag/Cluster/operation/CreateCluster).\n\n#### Step 4: Get the new cluster information\n\nAfter you successfully create a cluster, you can use the [Get cluster by ID](#tag/Cluster/operation/GetCluster) endpoint to get the information of the cluster.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_cluster_by_id(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Get the cluster detail.\n    You will get `connection_strings` from the response after the cluster's status is`AVAILABLE`.\n    Then, you can connect to TiDB using the default user, host, and port in `connection_strings`\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :return: The cluster detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    resp = requests.get(url=url,\n                        auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    cluster = get_cluster_by_id(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                       \"{YOUR_CLUSTER_ID}\")\n    print(cluster)\n```\n\nIn the response, you can see the `connection_strings` field, which will be used later for connecting to the TiDB cluster. However, if your cluster status is `CREATING`, the `connection_strings` field might be empty. In such cases, you need to wait a while until the cluster status becomes `AVAILABLE` so that you can move on to the next step.\n\nFor more details about the request and response, see [Get a cluster by ID](#tag/Cluster/operation/GetCluster).\n\n#### Step 5: Connect to the cluster using a MySQL client\n\nAfter the cluster becomes `AVAILABLE`, you can get the connection strings. With the connection strings, you can connect to the cluster using a MySQL client.\n\nThe connection strings contain three fields:\n\n- `default_user`, the username you use to connect to TiDB.\n- `standard` connection string. In this guide, you'll use the `standard` connection.\n- `vpc_peering` connection string.\n\nThe `standard` connection string contains a `host` and a `port`. In the following command, replace `${default_user}` and `${host}` with the actual values in the connection strings. Run the command to connect to the TiDB cluster.\n\n```shell\nmysql --connect-timeout 15 -u ${default_user} -h ${host} -P 4000 -D test -p\n```\n\nFor more details on connection, see [Connect to TiDB Cluster](https://docs.pingcap.com/tidbcloud/connect-to-tidb-cluster).\n\n### Manage backups for your clusters\n\nThe following example shows how to create a manual backup and restore the last backup data to a new cluster.\n\n#### Step 1: Create a manual backup\n\nTo create a manual backup, you can use the [Create a backup for a cluster](#tag/Backup/operation/CreateBackup) endpoint.\n\n```python\nimport requests\nimport json\nimport datetime\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef create_manual_backup(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Create manual backup\n    `data_for_backup` below is a demo. You should fill in the field according to\n    your own situation\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The dedicated cluster id\n    :return: The backup id\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}/backups\"\n    cur_date = datetime.datetime.now().strftime(\"%Y-%m-%d\")\n    data_for_backup = {\"name\": f\"tidbcloud-backup-{cur_date}\", \"description\": f\"tidbcloud-backup-{cur_date}\"}\n    data_for_backup_json = json.dumps(data_for_backup)\n    resp = requests.post(url=url,\n                         data=data_for_backup_json,\n                         auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    backup = create_manual_backup(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                  \"{YOUR_CLUSTER_ID}\")\n    print(backup)\n```\n\n#### Step 2: Restore the last backup data to a new cluster\n\nTo restore the last backup data to a new cluster, you can use the [Create a restore task](#tag/Restore/operation/CreateRestoreTask) endpoint.\n\n```python\nimport requests\nimport json\nimport datetime\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef create_restore_task(public_key: str, private_key: str, project_id: str, back_up_id: str) -> dict:\n    \"\"\"\n    Create restore task\n    `data_for_restore` below is a demo. You should fill in the field according to\n    your own situation\n    :param private_key: Your public key\n    :param public_key: Your private key\n    :param project_id: The project id\n    :param back_up_id: The backup id\n    :return: The restore task id\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/restores\"\n    cur_date = datetime.datetime.now().strftime(\"%Y-%m-%d\")\n    data_for_restore = \\\n        {\n            \"backup_id\": f\"{back_up_id}\",\n            \"name\": f\"tidbcloud-restore-{cur_date}\",\n            \"config\":\n                {\n                    \"root_password\": \"input_your_password\",\n                    \"port\": 4000,\n                    \"components\":\n                        {\n                            \"tidb\":\n                                {\n                                    \"node_size\": \"8C16G\",\n                                    \"node_quantity\": 1\n                                },\n                            \"tikv\":\n                                {\n                                    \"node_size\": \"8C32G\",\n                                    \"storage_size_gib\": 500,\n                                    \"node_quantity\": 3\n                                }\n                        },\n                    \"ip_access_list\":\n                        [\n                            {\n                                \"cidr\": \"0.0.0.0/0\",\n                                \"description\": \"Allow Access from Anywhere.\"\n                            }\n                        ]\n\n                }\n        }\n    data_for_restore_json = json.dumps(data_for_restore)\n    resp = requests.post(url=url,\n                         auth=HTTPDigestAuth(public_key, private_key),\n                         data=data_for_restore_json)\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_BACKUP_ID\n    restore = create_restore_task(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                  \"{YOUR_BACKUP_ID}\")\n    print(restore)\n```\n\n#### Step 3: Get the restored cluster information\n\nTo get the information of the restored cluster, you can use the [Get a cluster by ID](#tag/Cluster/operation/GetCluster) endpoint.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_cluster_by_id(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Get the cluster detail.\n    You will get `connection_strings` from the response after the cluster's status is`AVAILABLE`.\n    Then, you can connect to TiDB using the default user, host, and port in `connection_strings`\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :return: The cluster detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    resp = requests.get(url=url,\n                        auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    cluster = get_cluster_by_id(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                       \"{YOUR_CLUSTER_ID}\")\n    print(cluster)\n```\n\n### Scale out one TiFlash node for an existing cluster\n\nThe following example shows how to scale out one TiFlash node for an existing cluster.\n\n#### Step 1: Add one TiFlash node for the specified cluster\n\nTo add a TiFlash node for the Dedicated Tier cluster, you can use the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n\n```python\nimport requests\nimport json\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef modify_cluster(public_key: str, private_key: str, project_id: str, cluster_id: str, tiflash_num: int) -> dict:\n    \"\"\"\n    Add one TiFlash node for specified cluster\n    If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n    `data_add_tiflash` below is a demo. You should fill in the field according to\n    your own situation\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :param tiflash_num: The tiflash num\n    :return: If success, return None. Else, return message\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    data_add_tiflash = \\\n        {\n            \"config\":\n                {\n                    \"components\":\n                        {\n                            \"tidb\":\n                                {\n                                    \"node_quantity\": 1\n                                },\n                            \"tikv\":\n                                {\n                                    \"node_quantity\": 3\n                                },\n                            \"tiflash\":\n                                {\n                                    \"node_quantity\": f\"{tiflash_num}\",\n                                    \"node_size\": \"8C64G\",\n                                    \"storage_size_gib\": 500\n                                }\n                        }\n                }\n        }\n    data_add_tiflash_json = json.dumps(data_add_tiflash)\n    resp = requests.patch(url=url,\n                          auth=HTTPDigestAuth(public_key, private_key),\n                          data=data_add_tiflash_json)\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID, YOUR_CLUSTER_ID and MODIFY_TIFLASH_NUM\n    modify_cluster(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                   \"{YOUR_CLUSTER_ID}\", \"{MODIFY_TIFLASH_NUM}\")\n```\n\n#### Step 2: View the scale-out progress\n\nTo view the scale-out progress, you can use the [Get a cluster by ID](#tag/Cluster/operation/GetCluster) endpoint.\n\n```python\nimport requests\nfrom requests.auth import HTTPDigestAuth\n\nHOST = \"https://api.tidbcloud.com\"\n\n\ndef get_cluster_by_id(public_key: str, private_key: str, project_id: str, cluster_id: str) -> dict:\n    \"\"\"\n    Get the cluster detail.\n    You will get `connection_strings` from the response after the cluster's status is`AVAILABLE`.\n    Then, you can connect to TiDB using the default user, host, and port in `connection_strings`\n    :param public_key: Your public key\n    :param private_key: Your private key\n    :param project_id: The project id\n    :param cluster_id: The cluster id\n    :return: The cluster detail\n    \"\"\"\n    url = f\"{HOST}/api/v1beta/projects/{project_id}/clusters/{cluster_id}\"\n    resp = requests.get(url=url,\n                        auth=HTTPDigestAuth(public_key, private_key))\n    if resp.status_code != 200:\n        print(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n        raise Exception(f\"request invalid, code : {resp.status_code}, message : {resp.text}\")\n    return resp.json()\n\n\nif __name__ == \"__main__\":\n    # Replace YOUR_PUBLIC_KEY, YOUR_PRIVATE_KEY, YOUR_PROJECT_ID and YOUR_CLUSTER_ID\n    cluster = get_cluster_by_id(\"{YOUR_PUBLIC_KEY}\", \"{YOUR_PRIVATE_KEY}\", \"{YOUR_PROJECT_ID}\",\n                                       \"{YOUR_CLUSTER_ID}\")\n    print(cluster)\n```\n\n# Authentication\n\nThe TiDB Cloud API uses [HTTP Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication). It protects your private key from being sent over the network. For more details about HTTP Digest Authentication, refer to the [IETF RFC](https://datatracker.ietf.org/doc/html/rfc7616).\n\n## API Key Overview\n\n- The API key contains a public key and a private key, which act as the username and password required in the HTTP Digest Authentication. The private key only displays upon the key creation.\n- The API key belongs to your organization and acts as the `Owner` role. You can check [permissions of owner](https://docs.pingcap.com/tidbcloud/manage-user-access#configure-member-roles).\n- You must provide the correct API key in every request. Otherwise, the TiDB Cloud responds with a `401` error.\n\n## API Key Management\n\n### Create an API Key\n\nOnly the **owner** of an organization can create an API key.\n\nTo create an API key in an organization, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab and then click **Create API Key**.\n4. Enter a description for your API key. The role of the API key is always `Owner` currently.\n5. Click **Next**. Copy and save the public key and the private key.\n6. Make sure that you have copied and saved the private key in a secure location. The private key only displays upon the creation. After leaving this page, you will not be able to get the full private key again.\n7. Click **Done**.\n\n### View Details of an API Key\n\nTo view details of an API key, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab.\n4. You can view the details of the API keys in the menu.\n\n### Edit an API Key\n\nOnly the **owner** of an organization can modify an API key.\n\nTo edit an API key in an organization, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab.\n4. Click **Edit** in the API key row that you want to change.\n4. You can update the API key description.\n5. Click **Done**.\n\n### Delete an API key\n\nOnly the **owner** of an organization can delete an API key.\n\nTo delete an API key in an organization, perform the following steps:\n\n1. Click the account name in the upper-right corner of the TiDB Cloud console.\n2. Click **Organization Settings**. The organization settings page is displayed.\n3. Click the **API Keys** tab.\n4. Click **Delete** in the API key row that you want to delete.\n5. Click **I understand the consequences, delete this API Key.**\n\n# Rate Limiting\n\n\nThe TiDB Cloud API allows up to 100 requests per minute per API key. If you exceed the rate limit, the API returns a `429` error.\n\nEach API request returns the following headers about the limit.\n\n- `X-Ratelimit-Limit-Minute`: The number of requests allowed per minute. It is 100 currently.\n- `X-Ratelimit-Remaining-Minute`: The number of remaining requests in the current minute. When it reaches `0`, the API returns a `429` error and indicates that you exceed the rate limit.\n- `X-Ratelimit-Reset`: The time in seconds at which the current rate limit resets.\n\nIf you exceed the rate limit, an error response returns like this.\n\n```\n> HTTP/2 429\n> date: Fri, 22 Jul 2022 05:28:37 GMT\n> content-type: application/json\n> content-length: 66\n> x-ratelimit-reset: 23\n> x-ratelimit-remaining-minute: 0\n> x-ratelimit-limit-minute: 100\n> x-kong-response-latency: 2\n> server: kong/2.8.1\n\n> {\"details\":[],\"code\":49900007,\"message\":\"API rate limit exceeded\"}\n```\n\n# API Changelog\n\nThis changelog lists all changes to the TiDB Cloud API.\n\n<!-- In reverse chronological order -->\n\n## 20230104\n\n- Add three fields to the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint. These fields support scaling up node sizes, but not scaling down.\n\n    - `config.components.tidb.node_size`\n    - `config.components.tikv.node_size`\n    - `config.components.tiflash.node_size`\n\n## 20221028\n\n- [Developer Tier is upgraded to Serverless Tier](https://docs.pingcap.com/tidbcloud/release-notes-2022#october-28-2022). Serverless Tier is still in beta and free to use.\n\n    [Creating a cluster](#tag/Cluster/operation/CreateCluster) with the `cluster_type` field set to `\"DEVELOPER\"` creates a Serverless Tier cluster now.\n\n## 20220920\n\n- The API is now in public beta and available to all users.\n\n## 20220906\n\n- Add a `config.components.tikv.storage_size_gib` field to the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n- Modify the `config.components.tikv.node_quantity` and `config.components.tiflash.node_quantity` fields from `required` to `optional` for the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n- Remove the \"Can not modify `storage_size_gib` of an existing cluster\" limitation of the `config.components.tiflash.storage_size_gib` field for the [Create a cluster](#tag/Cluster/operation/CreateCluster) and [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoints.\n\n## 20220823\n\n- Add a `config.paused` field to the [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster) endpoint.\n- Add two cluster statuses: `\"IMPORTING\"` and `\"UNAVAILABLE\"`.\n\n## 20220809\n\n- Initial release of the TiDB Cloud API (v1beta) in private beta, including the following resources and endpoints:\n\n    - Project:\n\n        - [List all accessible projects](#tag/Project/operation/ListProjects)\n\n    - Cluster:\n        - [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions)\n        - [List all clusters in a project](/#tag/Cluster/operation/ListClustersOfProject)\n        - [Create a cluster](#tag/Cluster/operation/CreateCluster)\n        - [Get a cluster by ID](#tag/Cluster/operation/GetCluster)\n        - [Delete a cluster](#tag/Cluster/operation/DeleteCluster)\n        - [Modify a Dedicated Tier cluster](#tag/Cluster/operation/UpdateCluster)\n    - Backup:\n        - [List all backups for a cluster](#tag/Backup/operation/ListBackUpOfCluster)\n        - [Create a backup for a cluster](#tag/Backup/operation/CreateBackup)\n        - [Get a backup for a cluster](#tag/Backup/operation/GetBackupOfCluster)\n        - [Delete a backup for a cluster](#tag/Backup/operation/DeleteBackup)\n    - Restore:\n        - [List the restore tasks in a project](#tag/Restore/operation/ListRestoreTasks)\n        - [Create a restore task](#tag/Restore/operation/CreateRestoreTask)\n        - [Get a restore task](#tag/Restore/operation/GetRestoreTask)\n",
     "version": "v1-beta",
     "x-logo": {
       "url": "https://download.pingcap.org/tidbcloud-logo-for-api-docs.png",
@@ -21,11 +21,11 @@
     },
     {
       "name": "Backup",
-      "description": "Create, get, modify, and delete backups for TiDB clusters.\n\nFor Developer Tier clusters, you cannot create or manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups."
+      "description": "Create, get, modify, and delete backups for TiDB clusters.\n\nFor Serverless Tier clusters, you cannot create or manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups."
     },
     {
       "name": "Restore",
-      "description": "Get and create restore tasks for TiDB clusters. You can only restore data to a new cluster.\n\nFor more information on restoration on TiDB Cloud, refer to [Restore](https://docs.pingcap.com/tidbcloud/backup-and-restore#restore).\n\nFor Developer Tier clusters, you cannot manage restore tasks via API."
+      "description": "Get and create restore tasks for TiDB clusters. You can only restore data to a new cluster.\n\nFor more information on restoration on TiDB Cloud, refer to [Restore](https://docs.pingcap.com/tidbcloud/backup-and-restore#restore).\n\nFor Serverless Tier clusters, you cannot manage restore tasks via API."
     }
   ],
   "host": "api.tidbcloud.com",
@@ -68,7 +68,7 @@
                       ],
                       "tikv": [
                         {
-                          "node_size": "8C64G",
+                          "node_size": "8C32G",
                           "node_quantity_range": {
                             "min": 3,
                             "step": 3
@@ -140,7 +140,7 @@
                       "cluster_type": {
                         "format": "enum",
                         "example": "DEDICATED",
-                        "description": "The cluster type.\n- `\"DEVELOPER\"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster",
+                        "description": "The cluster type.\n- `\"DEVELOPER\"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster\n\n**Warning:** `\"DEVELOPER\"` will soon be changed to `\"SERVERLESS\"` to represent Serverless Tier clusters.",
                         "type": "string",
                         "enum": [
                           "DEDICATED",
@@ -199,7 +199,7 @@
                           "properties": {
                             "node_size": {
                               "type": "string",
-                              "example": "8C64G",
+                              "example": "8C32G",
                               "description": "The size of the TiKV component in the cluster."
                             },
                             "node_quantity_range": {
@@ -778,7 +778,7 @@
                       "cluster_type": {
                         "format": "enum",
                         "example": "DEDICATED",
-                        "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.",
+                        "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster\n\n**Warning:** `\"DEVELOPER\"` will soon be changed to `\"SERVERLESS\"` to represent Serverless Tier clusters.",
                         "type": "string",
                         "enum": [
                           "DEDICATED",
@@ -815,7 +815,7 @@
                               "node_quantity": 2
                             },
                             "tikv": {
-                              "node_size": "8C64G",
+                              "node_size": "8C32G",
                               "storage_size_gib": 1024,
                               "node_quantity": 3
                             }
@@ -840,7 +840,7 @@
                                 "node_quantity": 2
                               },
                               "tikv": {
-                                "node_size": "8C64G",
+                                "node_size": "8C32G",
                                 "storage_size_gib": 1024,
                                 "node_quantity": 3
                               }
@@ -855,7 +855,7 @@
                                   "node_size": {
                                     "type": "string",
                                     "example": "8C16G",
-                                    "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                                    "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                                   },
                                   "node_quantity": {
                                     "type": "integer",
@@ -876,7 +876,7 @@
                                   "node_size": {
                                     "type": "string",
                                     "example": "8C64G",
-                                    "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                                    "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                                   },
                                   "storage_size_gib": {
                                     "type": "integer",
@@ -904,7 +904,7 @@
                                   "node_size": {
                                     "type": "string",
                                     "example": "8C64G",
-                                    "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                                    "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                                   },
                                   "storage_size_gib": {
                                     "type": "integer",
@@ -1032,7 +1032,7 @@
                                   {
                                     "node_name": "tikv-0",
                                     "availability_zone": "us-west-2a",
-                                    "node_size": "8C64G",
+                                    "node_size": "8C32G",
                                     "vcpu_num": 8,
                                     "ram_bytes": "68719476736",
                                     "storage_size_gib": 1024,
@@ -1072,7 +1072,7 @@
                                     },
                                     "node_size": {
                                       "type": "string",
-                                      "example": "8C64G",
+                                      "example": "8C32G",
                                       "description": "The size of the TiKV component in the cluster."
                                     },
                                     "vcpu_num": {
@@ -1210,7 +1210,7 @@
                                     "format": "int32",
                                     "example": 4000,
                                     "default": 4000,
-                                    "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                                    "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                                     "maximum": 65535,
                                     "minimum": 1024
                                   }
@@ -1230,7 +1230,7 @@
                                     "format": "int32",
                                     "example": 4000,
                                     "default": 4000,
-                                    "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                                    "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                                     "maximum": 65535,
                                     "minimum": 1024
                                   }
@@ -1687,7 +1687,7 @@
                 "cluster_type": {
                   "format": "enum",
                   "example": "DEDICATED",
-                  "description": "The cluster type.\n- `\"DEVELOPER\"`: create a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: create a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster. Before creating a Dedicated Tier cluster, you must [set a Project CIDR](https://docs.pingcap.com/tidbcloud/set-up-vpc-peering-connections#prerequisite-set-a-project-cidr) on [TiDB Cloud console](https://tidbcloud.com/).",
+                  "description": "The cluster type.\n- `\"DEVELOPER\"`: create a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: create a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster. Before creating a Dedicated Tier cluster, you must [set a Project CIDR](https://docs.pingcap.com/tidbcloud/set-up-vpc-peering-connections#prerequisite-set-a-project-cidr) on [TiDB Cloud console](https://tidbcloud.com/).",
                   "type": "string",
                   "enum": [
                     "DEDICATED",
@@ -1725,7 +1725,7 @@
                       "format": "int32",
                       "example": 4000,
                       "default": 4000,
-                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                       "maximum": 65535,
                       "minimum": 1024
                     },
@@ -1736,12 +1736,12 @@
                           "node_quantity": 2
                         },
                         "tikv": {
-                          "node_size": "8C64G",
+                          "node_size": "8C32G",
                           "storage_size_gib": 1024,
                           "node_quantity": 3
                         }
                       },
-                      "description": "The components of the cluster.\n\n**Limitations**:\n- For a Dedicated Tier cluster, the `components` parameter is **required**.\n- For a Developer Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.",
+                      "description": "The components of the cluster.\n\n**Limitations**:\n- For a Dedicated Tier cluster, the `components` parameter is **required**.\n- For a Serverless Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.",
                       "type": "object",
                       "properties": {
                         "tidb": {
@@ -1751,7 +1751,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C16G",
-                              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                             },
                             "node_quantity": {
                               "type": "integer",
@@ -1772,7 +1772,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C64G",
-                              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                             },
                             "storage_size_gib": {
                               "type": "integer",
@@ -1800,7 +1800,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C64G",
-                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                             },
                             "storage_size_gib": {
                               "type": "integer",
@@ -1873,10 +1873,10 @@
         "x-code-samples": [
           {
             "lang": "curl for Dedicated Tier",
-            "source": "curl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request POST \\\n  --url https://api.tidbcloud.com/api/v1beta/projects/{project_id}/clusters \\\n  --header 'content-type: application/json' \\\n  --data '{\"name\":\"Cluster0\",\"cluster_type\":\"DEDICATED\",\"cloud_provider\":\"AWS\",\"region\":\"us-west-2\",\"config\":{\"root_password\":\"password_example\",\"port\":4000,\"components\":{\"tidb\":{\"node_size\":\"8C16G\",\"node_quantity\":2},\"tikv\":{\"node_size\":\"8C64G\",\"storage_size_gib\":1024,\"node_quantity\":3}},\"ip_access_list\":[{\"cidr\":\"8.8.8.8/32\",\"description\":\"My Current IP Address\"}]}}'"
+            "source": "curl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request POST \\\n  --url https://api.tidbcloud.com/api/v1beta/projects/{project_id}/clusters \\\n  --header 'content-type: application/json' \\\n  --data '{\"name\":\"Cluster0\",\"cluster_type\":\"DEDICATED\",\"cloud_provider\":\"AWS\",\"region\":\"us-west-2\",\"config\":{\"root_password\":\"password_example\",\"port\":4000,\"components\":{\"tidb\":{\"node_size\":\"8C16G\",\"node_quantity\":2},\"tikv\":{\"node_size\":\"8C32G\",\"storage_size_gib\":1024,\"node_quantity\":3}},\"ip_access_list\":[{\"cidr\":\"8.8.8.8/32\",\"description\":\"My Current IP Address\"}]}}'"
           },
           {
-            "lang": "curl for Developer Tier",
+            "lang": "curl for Serverless Tier",
             "source": "curl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request POST \\\n  --url https://api.tidbcloud.com/api/v1beta/projects/{project_id}/clusters \\\n  --header 'content-type: application/json' \\\n  --data '{\"name\":\"Cluster0\",\"cluster_type\":\"DEVELOPER\",\"cloud_provider\":\"AWS\",\"region\":\"us-west-2\",\"config\":{\"root_password\":\"password_example\",\"ip_access_list\":[{\"cidr\":\"8.8.8.8/32\",\"description\":\"My IP Address\"}]}}'"
           }
         ]
@@ -1913,7 +1913,7 @@
                 "cluster_type": {
                   "format": "enum",
                   "example": "DEDICATED",
-                  "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.",
+                  "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster\n\n**Warning:** `\"DEVELOPER\"` will soon be changed to `\"SERVERLESS\"` to represent Serverless Tier clusters.",
                   "type": "string",
                   "enum": [
                     "DEDICATED",
@@ -1950,7 +1950,7 @@
                         "node_quantity": 2
                       },
                       "tikv": {
-                        "node_size": "8C64G",
+                        "node_size": "8C32G",
                         "storage_size_gib": 1024,
                         "node_quantity": 3
                       }
@@ -1975,7 +1975,7 @@
                           "node_quantity": 2
                         },
                         "tikv": {
-                          "node_size": "8C64G",
+                          "node_size": "8C32G",
                           "storage_size_gib": 1024,
                           "node_quantity": 3
                         }
@@ -1990,7 +1990,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C16G",
-                              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                             },
                             "node_quantity": {
                               "type": "integer",
@@ -2011,7 +2011,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C64G",
-                              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                             },
                             "storage_size_gib": {
                               "type": "integer",
@@ -2039,7 +2039,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C64G",
-                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                             },
                             "storage_size_gib": {
                               "type": "integer",
@@ -2167,7 +2167,7 @@
                             {
                               "node_name": "tikv-0",
                               "availability_zone": "us-west-2a",
-                              "node_size": "8C64G",
+                              "node_size": "8C32G",
                               "vcpu_num": 8,
                               "ram_bytes": "68719476736",
                               "storage_size_gib": 1024,
@@ -2207,7 +2207,7 @@
                               },
                               "node_size": {
                                 "type": "string",
-                                "example": "8C64G",
+                                "example": "8C32G",
                                 "description": "The size of the TiKV component in the cluster."
                               },
                               "vcpu_num": {
@@ -2345,7 +2345,7 @@
                               "format": "int32",
                               "example": 4000,
                               "default": 4000,
-                              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                               "maximum": 65535,
                               "minimum": 1024
                             }
@@ -2365,7 +2365,7 @@
                               "format": "int32",
                               "example": 4000,
                               "default": 4000,
-                              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                               "maximum": 65535,
                               "minimum": 1024
                             }
@@ -2993,15 +2993,17 @@
                   "example": {
                     "components": {
                       "tidb": {
+                        "node_size": "16C32G",
                         "node_quantity": 3
                       },
                       "tikv": {
-                        "storage_size_gib": 1024,
+                        "node_size": "16C64G",
+                        "storage_size_gib": 2048,
                         "node_quantity": 6
                       },
                       "tiflash": {
-                        "node_size": "8C64G",
-                        "storage_size_gib": 1024,
+                        "node_size": "16C128G",
+                        "storage_size_gib": 2048,
                         "node_quantity": 2
                       }
                     }
@@ -3017,25 +3019,32 @@
                           "description": "The TiDB component of the cluster.",
                           "type": "object",
                           "properties": {
+                            "node_size": {
+                              "type": "string",
+                              "example": "16C32G",
+                              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiDB.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+                            },
                             "node_quantity": {
                               "type": "integer",
                               "format": "int32",
                               "example": 3,
                               "description": "The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions)."
                             }
-                          },
-                          "required": [
-                            "node_quantity"
-                          ]
+                          }
                         },
                         "tikv": {
                           "description": "The TiKV component of the cluster.",
                           "type": "object",
                           "properties": {
+                            "node_size": {
+                              "type": "string",
+                              "example": "16C64G",
+                              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiKV.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+                            },
                             "storage_size_gib": {
                               "type": "integer",
                               "format": "int32",
-                              "example": 1024,
+                              "example": 2048,
                               "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiKV.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again."
                             },
                             "node_quantity": {
@@ -3052,13 +3061,13 @@
                           "properties": {
                             "node_size": {
                               "type": "string",
-                              "example": "8C64G",
-                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                              "example": "16C128G",
+                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiFlash.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
                             },
                             "storage_size_gib": {
                               "type": "integer",
                               "format": "int32",
-                              "example": 1024,
+                              "example": 2048,
                               "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiFlash.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again."
                             },
                             "node_quantity": {
@@ -3093,7 +3102,7 @@
         "x-code-samples": [
           {
             "lang": "curl",
-            "source": "curl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request PATCH \\\n  --url https://api.tidbcloud.com/api/v1beta/projects/{project_id}/clusters/{cluster_id} \\\n  --header 'content-type: application/json' \\\n  --data '{\"config\":{\"components\":{\"tidb\":{\"node_quantity\":3},\"tikv\":{\"storage_size_gib\":1024,\"node_quantity\":6},\"tiflash\":{\"node_size\":\"8C64G\",\"storage_size_gib\":1024,\"node_quantity\":2}}}}'"
+            "source": "curl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request PATCH \\\n  --url https://api.tidbcloud.com/api/v1beta/projects/{project_id}/clusters/{cluster_id} \\\n  --header 'content-type: application/json' \\\n  --data '{\"config\":{\"components\":{\"tidb\":{\"node_size\":\"16C32G\",\"node_quantity\":3},\"tikv\":{\"node_size\":\"16C64G\",\"storage_size_gib\":2048,\"node_quantity\":6},\"tiflash\":{\"node_size\":\"16C128G\",\"storage_size_gib\":2048,\"node_quantity\":2}}}}'"
           }
         ]
       }
@@ -3101,7 +3110,7 @@
     "/api/v1beta/projects/{project_id}/clusters/{cluster_id}/backups": {
       "get": {
         "summary": "List all backups for a cluster.",
-        "description": "For Developer Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
+        "description": "For Serverless Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
         "operationId": "ListBackUpOfCluster",
         "responses": {
           "200": {
@@ -3394,7 +3403,7 @@
       },
       "post": {
         "summary": "Create a backup for a cluster.",
-        "description": "- For Dedicated Tier clusters, you can create as many manual backups as you need.\n- For Developer Tier clusters, you cannot create backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
+        "description": "- For Dedicated Tier clusters, you can create as many manual backups as you need.\n- For Serverless Tier clusters, you cannot create backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
         "operationId": "CreateBackup",
         "responses": {
           "200": {
@@ -3637,7 +3646,7 @@
     "/api/v1beta/projects/{project_id}/clusters/{cluster_id}/backups/{backup_id}": {
       "get": {
         "summary": "Get a backup for a cluster.",
-        "description": "For Developer Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
+        "description": "For Serverless Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
         "operationId": "GetBackupOfCluster",
         "responses": {
           "200": {
@@ -3903,7 +3912,7 @@
       },
       "delete": {
         "summary": "Delete a backup for a cluster.",
-        "description": "For Developer Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
+        "description": "For Serverless Tier clusters, you cannot manage backups via API. You can use [Dumpling](https://docs.pingcap.com/tidb/stable/dumpling-overview) to export your data as backups.",
         "operationId": "DeleteBackup",
         "responses": {
           "200": {
@@ -4120,7 +4129,7 @@
     "/api/v1beta/projects/{project_id}/restores": {
       "get": {
         "summary": "List the restore tasks in a project.",
-        "description": "\nFor Developer Tier clusters, you cannot create or manage restore tasks via API.",
+        "description": "\nFor Serverless Tier clusters, you cannot create or manage restore tasks via API.",
         "operationId": "ListRestoreTasks",
         "responses": {
           "200": {
@@ -4420,7 +4429,7 @@
       },
       "post": {
         "summary": "Create a restore task.",
-        "description": "You can use this endpoint to restore data from a previously created backup file to a new cluster. In this endpoint, you must specify the configuration of the new cluster you want to restore data to.\n\n**Limitations:**\n\n- For Dedicated Tier, you can only restore data from a smaller node size to a larger node size.\n\n- You cannot restore data from a Dedicated Tier cluster to a Developer Tier cluster.\n\nFor Developer Tier clusters, you cannot create restore tasks via API.",
+        "description": "You can use this endpoint to restore data from a previously created backup file to a new cluster. In this endpoint, you must specify the configuration of the new cluster you want to restore data to.\n\n**Limitations:**\n\n- For Dedicated Tier, you can only restore data from a smaller node size to a larger node size.\n\n- You cannot restore data from a Dedicated Tier cluster to a Serverless Tier cluster.\n\nFor Serverless Tier clusters, you cannot create restore tasks via API.",
         "operationId": "CreateRestoreTask",
         "responses": {
           "200": {
@@ -4656,7 +4665,7 @@
                       "format": "int32",
                       "example": 4000,
                       "default": 4000,
-                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                       "maximum": 65535,
                       "minimum": 1024
                     },
@@ -4667,12 +4676,12 @@
                           "node_quantity": 2
                         },
                         "tikv": {
-                          "node_size": "8C64G",
+                          "node_size": "8C32G",
                           "storage_size_gib": 1024,
                           "node_quantity": 3
                         }
                       },
-                      "description": "The components of the cluster.\n\n**Limitations**:\n- For a Dedicated Tier cluster, the `components` parameter is **required**.\n- For a Developer Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.",
+                      "description": "The components of the cluster.\n\n**Limitations**:\n- For a Dedicated Tier cluster, the `components` parameter is **required**.\n- For a Serverless Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.",
                       "type": "object",
                       "properties": {
                         "tidb": {
@@ -4682,7 +4691,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C16G",
-                              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                             },
                             "node_quantity": {
                               "type": "integer",
@@ -4703,7 +4712,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C64G",
-                              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                             },
                             "storage_size_gib": {
                               "type": "integer",
@@ -4731,7 +4740,7 @@
                             "node_size": {
                               "type": "string",
                               "example": "8C64G",
-                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                             },
                             "storage_size_gib": {
                               "type": "integer",
@@ -4802,7 +4811,7 @@
         "x-code-samples": [
           {
             "lang": "curl",
-            "source": "curl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request POST \\\n  --url https://api.tidbcloud.com/api/v1beta/projects/{project_id}/restores \\\n  --header 'content-type: application/json' \\\n  --data '{\"backup_id\":\"1\",\"name\":\"Cluster0\",\"config\":{\"root_password\":\"password_example\",\"port\":4000,\"components\":{\"tidb\":{\"node_size\":\"8C16G\",\"node_quantity\":2},\"tikv\":{\"node_size\":\"8C64G\",\"storage_size_gib\":1024,\"node_quantity\":3}},\"ip_access_list\":[{\"cidr\":\"8.8.8.8/32\",\"description\":\"My Current IP Address\"}]}}'"
+            "source": "curl --digest \\\n  --user 'YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY' \\\n  --request POST \\\n  --url https://api.tidbcloud.com/api/v1beta/projects/{project_id}/restores \\\n  --header 'content-type: application/json' \\\n  --data '{\"backup_id\":\"1\",\"name\":\"Cluster0\",\"config\":{\"root_password\":\"password_example\",\"port\":4000,\"components\":{\"tidb\":{\"node_size\":\"8C16G\",\"node_quantity\":2},\"tikv\":{\"node_size\":\"8C32G\",\"storage_size_gib\":1024,\"node_quantity\":3}},\"ip_access_list\":[{\"cidr\":\"8.8.8.8/32\",\"description\":\"My Current IP Address\"}]}}'"
           }
         ]
       }
@@ -4810,7 +4819,7 @@
     "/api/v1beta/projects/{project_id}/restores/{restore_id}": {
       "get": {
         "summary": "Get a restore task.",
-        "description": "\nFor Developer Tier clusters, you cannot manage restore tasks via API.",
+        "description": "\nFor Serverless Tier clusters, you cannot manage restore tasks via API.",
         "operationId": "GetRestoreTask",
         "responses": {
           "200": {
@@ -5132,7 +5141,7 @@
             "node_size": {
               "type": "string",
               "example": "8C16G",
-              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
             },
             "node_quantity": {
               "type": "integer",
@@ -5153,7 +5162,7 @@
             "node_size": {
               "type": "string",
               "example": "8C64G",
-              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
             },
             "storage_size_gib": {
               "type": "integer",
@@ -5181,7 +5190,7 @@
             "node_size": {
               "type": "string",
               "example": "8C64G",
-              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
             },
             "storage_size_gib": {
               "type": "integer",
@@ -5223,7 +5232,7 @@
           "format": "int32",
           "example": 4000,
           "default": 4000,
-          "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+          "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
           "maximum": 65535,
           "minimum": 1024
         },
@@ -5234,12 +5243,12 @@
               "node_quantity": 2
             },
             "tikv": {
-              "node_size": "8C64G",
+              "node_size": "8C32G",
               "storage_size_gib": 1024,
               "node_quantity": 3
             }
           },
-          "description": "The components of the cluster.\n\n**Limitations**:\n- For a Dedicated Tier cluster, the `components` parameter is **required**.\n- For a Developer Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.",
+          "description": "The components of the cluster.\n\n**Limitations**:\n- For a Dedicated Tier cluster, the `components` parameter is **required**.\n- For a Serverless Tier cluster, the `components` value is **ignored**. Setting this configuration does not have any effects.",
           "type": "object",
           "properties": {
             "tidb": {
@@ -5249,7 +5258,7 @@
                 "node_size": {
                   "type": "string",
                   "example": "8C16G",
-                  "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                  "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                 },
                 "node_quantity": {
                   "type": "integer",
@@ -5270,7 +5279,7 @@
                 "node_size": {
                   "type": "string",
                   "example": "8C64G",
-                  "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                  "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                 },
                 "storage_size_gib": {
                   "type": "integer",
@@ -5298,7 +5307,7 @@
                 "node_size": {
                   "type": "string",
                   "example": "8C64G",
-                  "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                  "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                 },
                 "storage_size_gib": {
                   "type": "integer",
@@ -5374,7 +5383,7 @@
               "format": "int32",
               "example": 4000,
               "default": 4000,
-              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
               "maximum": 65535,
               "minimum": 1024
             }
@@ -5394,7 +5403,7 @@
               "format": "int32",
               "example": 4000,
               "default": 4000,
-              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+              "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
               "maximum": 65535,
               "minimum": 1024
             }
@@ -5449,7 +5458,7 @@
         "cluster_type": {
           "format": "enum",
           "example": "DEDICATED",
-          "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.",
+          "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster\n\n**Warning:** `\"DEVELOPER\"` will soon be changed to `\"SERVERLESS\"` to represent Serverless Tier clusters.",
           "type": "string",
           "enum": [
             "DEDICATED",
@@ -5486,7 +5495,7 @@
                 "node_quantity": 2
               },
               "tikv": {
-                "node_size": "8C64G",
+                "node_size": "8C32G",
                 "storage_size_gib": 1024,
                 "node_quantity": 3
               }
@@ -5511,7 +5520,7 @@
                   "node_quantity": 2
                 },
                 "tikv": {
-                  "node_size": "8C64G",
+                  "node_size": "8C32G",
                   "storage_size_gib": 1024,
                   "node_quantity": 3
                 }
@@ -5526,7 +5535,7 @@
                     "node_size": {
                       "type": "string",
                       "example": "8C16G",
-                      "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                      "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                     },
                     "node_quantity": {
                       "type": "integer",
@@ -5547,7 +5556,7 @@
                     "node_size": {
                       "type": "string",
                       "example": "8C64G",
-                      "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                      "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                     },
                     "storage_size_gib": {
                       "type": "integer",
@@ -5575,7 +5584,7 @@
                     "node_size": {
                       "type": "string",
                       "example": "8C64G",
-                      "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                      "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                     },
                     "storage_size_gib": {
                       "type": "integer",
@@ -5703,7 +5712,7 @@
                     {
                       "node_name": "tikv-0",
                       "availability_zone": "us-west-2a",
-                      "node_size": "8C64G",
+                      "node_size": "8C32G",
                       "vcpu_num": 8,
                       "ram_bytes": "68719476736",
                       "storage_size_gib": 1024,
@@ -5743,7 +5752,7 @@
                       },
                       "node_size": {
                         "type": "string",
-                        "example": "8C64G",
+                        "example": "8C32G",
                         "description": "The size of the TiKV component in the cluster."
                       },
                       "vcpu_num": {
@@ -5881,7 +5890,7 @@
                       "format": "int32",
                       "example": 4000,
                       "default": 4000,
-                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                       "maximum": 65535,
                       "minimum": 1024
                     }
@@ -5901,7 +5910,7 @@
                       "format": "int32",
                       "example": 4000,
                       "default": 4000,
-                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                      "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                       "maximum": 65535,
                       "minimum": 1024
                     }
@@ -6018,7 +6027,7 @@
                 {
                   "node_name": "tikv-0",
                   "availability_zone": "us-west-2a",
-                  "node_size": "8C64G",
+                  "node_size": "8C32G",
                   "vcpu_num": 8,
                   "ram_bytes": "68719476736",
                   "storage_size_gib": 1024,
@@ -6058,7 +6067,7 @@
                   },
                   "node_size": {
                     "type": "string",
-                    "example": "8C64G",
+                    "example": "8C32G",
                     "description": "The size of the TiKV component in the cluster."
                   },
                   "vcpu_num": {
@@ -6196,7 +6205,7 @@
                   "format": "int32",
                   "example": 4000,
                   "default": 4000,
-                  "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                  "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                   "maximum": 65535,
                   "minimum": 1024
                 }
@@ -6216,7 +6225,7 @@
                   "format": "int32",
                   "example": 4000,
                   "default": 4000,
-                  "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                  "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                   "maximum": 65535,
                   "minimum": 1024
                 }
@@ -6302,7 +6311,7 @@
             {
               "node_name": "tikv-0",
               "availability_zone": "us-west-2a",
-              "node_size": "8C64G",
+              "node_size": "8C32G",
               "vcpu_num": 8,
               "ram_bytes": "68719476736",
               "storage_size_gib": 1024,
@@ -6342,7 +6351,7 @@
               },
               "node_size": {
                 "type": "string",
-                "example": "8C64G",
+                "example": "8C32G",
                 "description": "The size of the TiKV component in the cluster."
               },
               "vcpu_num": {
@@ -6607,7 +6616,7 @@
               "node_quantity": 2
             },
             "tikv": {
-              "node_size": "8C64G",
+              "node_size": "8C32G",
               "storage_size_gib": 1024,
               "node_quantity": 3
             }
@@ -6622,7 +6631,7 @@
                 "node_size": {
                   "type": "string",
                   "example": "8C16G",
-                  "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                  "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                 },
                 "node_quantity": {
                   "type": "integer",
@@ -6643,7 +6652,7 @@
                 "node_size": {
                   "type": "string",
                   "example": "8C64G",
-                  "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                  "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                 },
                 "storage_size_gib": {
                   "type": "integer",
@@ -6671,7 +6680,7 @@
                 "node_size": {
                   "type": "string",
                   "example": "8C64G",
-                  "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                  "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                 },
                 "storage_size_gib": {
                   "type": "integer",
@@ -6962,7 +6971,7 @@
               "cluster_type": {
                 "format": "enum",
                 "example": "DEDICATED",
-                "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster.",
+                "description": "The cluster type:\n- `\"DEVELOPER\"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster\n\n**Warning:** `\"DEVELOPER\"` will soon be changed to `\"SERVERLESS\"` to represent Serverless Tier clusters.",
                 "type": "string",
                 "enum": [
                   "DEDICATED",
@@ -6999,7 +7008,7 @@
                       "node_quantity": 2
                     },
                     "tikv": {
-                      "node_size": "8C64G",
+                      "node_size": "8C32G",
                       "storage_size_gib": 1024,
                       "node_quantity": 3
                     }
@@ -7024,7 +7033,7 @@
                         "node_quantity": 2
                       },
                       "tikv": {
-                        "node_size": "8C64G",
+                        "node_size": "8C32G",
                         "storage_size_gib": 1024,
                         "node_quantity": 3
                       }
@@ -7039,7 +7048,7 @@
                           "node_size": {
                             "type": "string",
                             "example": "8C16G",
-                            "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+                            "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
                           },
                           "node_quantity": {
                             "type": "integer",
@@ -7060,7 +7069,7 @@
                           "node_size": {
                             "type": "string",
                             "example": "8C64G",
-                            "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+                            "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
                           },
                           "storage_size_gib": {
                             "type": "integer",
@@ -7088,7 +7097,7 @@
                           "node_size": {
                             "type": "string",
                             "example": "8C64G",
-                            "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                            "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
                           },
                           "storage_size_gib": {
                             "type": "integer",
@@ -7216,7 +7225,7 @@
                           {
                             "node_name": "tikv-0",
                             "availability_zone": "us-west-2a",
-                            "node_size": "8C64G",
+                            "node_size": "8C32G",
                             "vcpu_num": 8,
                             "ram_bytes": "68719476736",
                             "storage_size_gib": 1024,
@@ -7256,7 +7265,7 @@
                             },
                             "node_size": {
                               "type": "string",
-                              "example": "8C64G",
+                              "example": "8C32G",
                               "description": "The size of the TiKV component in the cluster."
                             },
                             "vcpu_num": {
@@ -7394,7 +7403,7 @@
                             "format": "int32",
                             "example": 4000,
                             "default": 4000,
-                            "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                            "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                             "maximum": 65535,
                             "minimum": 1024
                           }
@@ -7414,7 +7423,7 @@
                             "format": "int32",
                             "example": 4000,
                             "default": 4000,
-                            "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+                            "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
                             "maximum": 65535,
                             "minimum": 1024
                           }
@@ -7560,7 +7569,7 @@
         "cluster_type": {
           "format": "enum",
           "example": "DEDICATED",
-          "description": "The cluster type.\n- `\"DEVELOPER\"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster",
+          "description": "The cluster type.\n- `\"DEVELOPER\"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster\n\n**Warning:** `\"DEVELOPER\"` will soon be changed to `\"SERVERLESS\"` to represent Serverless Tier clusters.",
           "type": "string",
           "enum": [
             "DEDICATED",
@@ -7619,7 +7628,7 @@
             "properties": {
               "node_size": {
                 "type": "string",
-                "example": "8C64G",
+                "example": "8C32G",
                 "description": "The size of the TiKV component in the cluster."
               },
               "node_quantity_range": {
@@ -7730,7 +7739,7 @@
               ],
               "tikv": [
                 {
-                  "node_size": "8C64G",
+                  "node_size": "8C32G",
                   "node_quantity_range": {
                     "min": 3,
                     "step": 3
@@ -7802,7 +7811,7 @@
               "cluster_type": {
                 "format": "enum",
                 "example": "DEDICATED",
-                "description": "The cluster type.\n- `\"DEVELOPER\"`: a [Developer Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#developer-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster",
+                "description": "The cluster type.\n- `\"DEVELOPER\"`: a [Serverless Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#serverless-tier) cluster\n- `\"DEDICATED\"`: a [Dedicated Tier](https://docs.pingcap.com/tidbcloud/select-cluster-tier#dedicated-tier) cluster\n\n**Warning:** `\"DEVELOPER\"` will soon be changed to `\"SERVERLESS\"` to represent Serverless Tier clusters.",
                 "type": "string",
                 "enum": [
                   "DEDICATED",
@@ -7861,7 +7870,7 @@
                   "properties": {
                     "node_size": {
                       "type": "string",
-                      "example": "8C64G",
+                      "example": "8C32G",
                       "description": "The size of the TiKV component in the cluster."
                     },
                     "node_quantity_range": {
@@ -8174,7 +8183,7 @@
           "format": "int32",
           "example": 4000,
           "default": 4000,
-          "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+          "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
           "maximum": 65535,
           "minimum": 1024
         }
@@ -8186,7 +8195,7 @@
         "node_size": {
           "type": "string",
           "example": "8C16G",
-          "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiDB of an existing cluster."
+          "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiDB."
         },
         "node_quantity": {
           "type": "integer",
@@ -8275,7 +8284,7 @@
         "node_size": {
           "type": "string",
           "example": "8C64G",
-          "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+          "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiFlash."
         },
         "storage_size_gib": {
           "type": "integer",
@@ -8393,7 +8402,7 @@
         "node_size": {
           "type": "string",
           "example": "8C64G",
-          "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiKV of an existing cluster."
+          "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease `node_size` for TiKV"
         },
         "storage_size_gib": {
           "type": "integer",
@@ -8429,7 +8438,7 @@
         },
         "node_size": {
           "type": "string",
-          "example": "8C64G",
+          "example": "8C32G",
           "description": "The size of the TiKV component in the cluster."
         },
         "vcpu_num": {
@@ -8468,7 +8477,7 @@
       "properties": {
         "node_size": {
           "type": "string",
-          "example": "8C64G",
+          "example": "8C32G",
           "description": "The size of the TiKV component in the cluster."
         },
         "node_quantity_range": {
@@ -8512,25 +8521,32 @@
           "description": "The TiDB component of the cluster.",
           "type": "object",
           "properties": {
+            "node_size": {
+              "type": "string",
+              "example": "16C32G",
+              "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiDB.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+            },
             "node_quantity": {
               "type": "integer",
               "format": "int32",
               "example": 3,
               "description": "The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions)."
             }
-          },
-          "required": [
-            "node_quantity"
-          ]
+          }
         },
         "tikv": {
           "description": "The TiKV component of the cluster.",
           "type": "object",
           "properties": {
+            "node_size": {
+              "type": "string",
+              "example": "16C64G",
+              "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiKV.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+            },
             "storage_size_gib": {
               "type": "integer",
               "format": "int32",
-              "example": 1024,
+              "example": 2048,
               "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiKV.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again."
             },
             "node_quantity": {
@@ -8547,13 +8563,13 @@
           "properties": {
             "node_size": {
               "type": "string",
-              "example": "8C64G",
-              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+              "example": "16C128G",
+              "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiFlash.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
             },
             "storage_size_gib": {
               "type": "integer",
               "format": "int32",
-              "example": 1024,
+              "example": 2048,
               "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiFlash.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again."
             },
             "node_quantity": {
@@ -8577,25 +8593,32 @@
               "description": "The TiDB component of the cluster.",
               "type": "object",
               "properties": {
+                "node_size": {
+                  "type": "string",
+                  "example": "16C32G",
+                  "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiDB.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+                },
                 "node_quantity": {
                   "type": "integer",
                   "format": "int32",
                   "example": 3,
                   "description": "The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions)."
                 }
-              },
-              "required": [
-                "node_quantity"
-              ]
+              }
             },
             "tikv": {
               "description": "The TiKV component of the cluster.",
               "type": "object",
               "properties": {
+                "node_size": {
+                  "type": "string",
+                  "example": "16C64G",
+                  "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiKV.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+                },
                 "storage_size_gib": {
                   "type": "integer",
                   "format": "int32",
-                  "example": 1024,
+                  "example": 2048,
                   "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiKV.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again."
                 },
                 "node_quantity": {
@@ -8612,13 +8635,13 @@
               "properties": {
                 "node_size": {
                   "type": "string",
-                  "example": "8C64G",
-                  "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+                  "example": "16C128G",
+                  "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiFlash.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
                 },
                 "storage_size_gib": {
                   "type": "integer",
                   "format": "int32",
-                  "example": 1024,
+                  "example": 2048,
                   "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiFlash.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again."
                 },
                 "node_quantity": {
@@ -8642,29 +8665,31 @@
     "openapiUpdateTiDBComponent": {
       "type": "object",
       "properties": {
+        "node_size": {
+          "type": "string",
+          "example": "16C32G",
+          "description": "The size of the TiDB component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiDB.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+        },
         "node_quantity": {
           "type": "integer",
           "format": "int32",
           "example": 3,
           "description": "The number of nodes in the cluster. You can get the minimum and step of a node quantity from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions)."
         }
-      },
-      "required": [
-        "node_quantity"
-      ]
+      }
     },
     "openapiUpdateTiFlashComponent": {
       "type": "object",
       "properties": {
         "node_size": {
           "type": "string",
-          "example": "8C64G",
-          "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot modify `node_size` for TiFlash of an existing cluster."
+          "example": "16C128G",
+          "description": "The size of the TiFlash component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiFlash.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
         },
         "storage_size_gib": {
           "type": "integer",
           "format": "int32",
-          "example": 1024,
+          "example": 2048,
           "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiFlash.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiFlash, you must wait at least six hours before you can change it again."
         },
         "node_quantity": {
@@ -8678,10 +8703,15 @@
     "openapiUpdateTiKVComponent": {
       "type": "object",
       "properties": {
+        "node_size": {
+          "type": "string",
+          "example": "16C64G",
+          "description": "The size of the TiKV component in the cluster. You can get the available node size of each region from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Additional combination rules**:\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n- If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n\n**Limitations**:\n- You cannot decrease node size for TiKV.\n- For other limitations, see [Increase node size](https://docs.pingcap.com/tidbcloud/scale-tidb-cluster#increase-node-size)."
+        },
         "storage_size_gib": {
           "type": "integer",
           "format": "int32",
-          "example": 1024,
+          "example": 2048,
           "description": "The storage size of a node in the cluster. You can get the minimum and maximum of storage size from the response of [List the cloud providers, regions and available specifications](#tag/Cluster/operation/ListProviderRegions).\n\n**Limitations**:\n- You cannot decrease storage size for TiKV.\n- If your TiDB cluster is hosted by AWS, after changing the storage size of TiKV, you must wait at least six hours before you can change it again."
         },
         "node_quantity": {
@@ -8705,7 +8735,7 @@
           "format": "int32",
           "example": 4000,
           "default": 4000,
-          "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Developer Tier cluster, only port `4000` is available.",
+          "description": "The TiDB port for connection. The port must be in the range of 1024-65535 except 10080.\n\n**Limitations**:\n- For a Serverless Tier cluster, only port `4000` is available.",
           "maximum": 65535,
           "minimum": 1024
         }


### PR DESCRIPTION
Open API has been updated in 20230104. https://docs.pingcap.com/tidbcloud/api/v1beta#section/API-Changelog

I download the newest swagger and generated the go SDK again with `swagger generate client -f ./tidbcloud-oas.json -A go-tidbcloud`. 

The key change of the SDK is:
- support modify the node_size of a dedicated cluster